### PR TITLE
Fix: 자동 재시작 문제 해결을 위한 DevTools 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,6 @@ dependencies {
     implementation 'software.amazon.awssdk:s3:2.31.7' // AWS SDK v2
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
 


### PR DESCRIPTION
## 🐛 Problem

애플리케이션이 개발 중 지속적으로 자동 재시작되는 문제가 발생했습니다.


### 에러 로그

2025-07-16T10:28:14.472+09:00  INFO 9676 --- [   File Watcher] rtingClassPathChangeChangedEventListener : Restarting due to 2 class path changes (0 additions, 0 deletions, 2 modifications)


---

## 🔍 Root Cause
- Spring Boot DevTools의 File Watcher가 클래스패스 변경을 감지하여 자동 재시작 트리거
- 개발 환경에서 의도치 않은 파일 변경으로 인한 불필요한 재시작 반복

## ✅ Solution
`spring-boot-devtools` 의존성을 제거하여 자동 재시작 기능을 비활성화했습니다.

### 변경사항
- `build.gradle`에서 `developmentOnly 'org.springframework.boot:spring-boot-devtools'` 제거

---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  
- [x] 변경 사항에 대한 테스트를 했습니다 (버그 수정/기능에 대한 테스트)

---

## 📚 Additional Notes
- DevTools는 개발 편의성 도구로, 핵심 애플리케이션 기능에는 영향 없음
- 필요시 나중에 다시 추가 가능 (`developmentOnly` 스코프로 운영환경에는 영향 없음)
- 수동 재시작이 필요한 경우 IDE의 재시작 기능 활용

## 🔗 Reference
- [Spring Boot DevTools Documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/using.html#using.devtools)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 환경에서 사용되던 `spring-boot-devtools` 의존성이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->