### PR TITLE
Feature: 파워 유저 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/model/BookScoreDto.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/model/BookScoreDto.java
@@ -10,6 +10,13 @@ public record BookScoreDto(
     long reviewCount,
     double averageRating
 ) {
+
+    /**
+     * 파워 유저 점수 계산을 위한 가중치
+     * - 리뷰 수: 40%
+     * - 평점: 60%
+     */
+
     private static final double REVIEW_COUNT_WEIGHT = 0.4;
     private static final double AVERAGE_RATING_WEIGHT = 0.6;
 

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
@@ -9,6 +9,14 @@ public record PowerUserScoreDto(
     long likeCount,
     long commentCount
 ) {
+
+    /**
+     * 파워 유저 점수 계산을 위한 가중치
+     * - 리뷰 점수: 50%
+     * - 좋아요 수: 20%
+     * - 댓글 수: 30%
+     */
+
     private static final double REVIEW_SCORE_WEIGHT = 0.5;
     private static final double LIKE_COUNT_WEIGHT = 0.2;
     private static final double COMMENT_COUNT_WEIGHT = 0.3;

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/model/ReviewScoreDto.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/model/ReviewScoreDto.java
@@ -14,6 +14,13 @@ public record ReviewScoreDto(
     long likeCount,
     long commentCount
 ) {
+
+    /**
+     * 파워 유저 점수 계산을 위한 가중치
+     * - 좋아요 수: 30%
+     * - 댓글 수: 70%
+     */
+
     private static final double LIKE_COUNT_WEIGHT = 0.3;
     private static final double COMMENT_COUNT_WEIGHT = 0.7;
 

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PowerUserRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PowerUserRankingScheduler.java
@@ -26,6 +26,8 @@ public class PowerUserRankingScheduler {
     public void runRankingJob() {
         String jobName = "powerUserRankingJob";
         String requestId = UUID.randomUUID().toString();
+        int successCount = 0;
+        int failureCount = 0;
 
         for (RankingPeriod period : RankingPeriod.values()) {
             try {
@@ -43,11 +45,16 @@ public class PowerUserRankingScheduler {
                 jobLauncher.run(powerUserRankingJob, params);
 
                 log.info("파워 유저 랭킹 배치 성공: period={}, requestId={}", period, requestId);
+                successCount++;
             } catch (Exception e) {
                 log.error("파워 유저 랭킹 배치 실패: period={}, requestId={}", period, requestId, e);
+                failureCount++;
             } finally {
                 MDC.clear();
             }
+
+            log.info("파워 유저 랭킹 배치 전체 완료: 성공={}, 실패={}, requestId={}",
+                successCount, failureCount, requestId);
         }
     }
 }

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
@@ -24,7 +24,7 @@ public class PowerUserRankingWriter implements ItemWriter<PowerUserRanking> {
 
         if (rankingList == null || rankingList.isEmpty()) {
             log.warn("파워 유저 랭킹 저장 스킵: 저장할 데이터가 없습니다.");
-            throw new DeokhugamException(ErrorCode.RANKING_DATA_EMPTY);
+            return;
         }
 
         try {
@@ -47,7 +47,7 @@ public class PowerUserRankingWriter implements ItemWriter<PowerUserRanking> {
             log.info("파워 유저 랭킹 {}건 저장 완료", rankingList.size());
         } catch (Exception e) {
             log.error("파워 유저 랭킹 저장 실패", e);
-            throw new DeokhugamException(ErrorCode.RANKING_SAVE_FAILED);
+            throw new DeokhugamException(ErrorCode.RANKING_SAVE_FAILED, e);
         }
     }
 }

--- a/src/main/java/com/twogether/deokhugam/dashboard/controller/PopularBookController.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/controller/PopularBookController.java
@@ -3,34 +3,28 @@ package com.twogether.deokhugam.dashboard.controller;
 import com.twogether.deokhugam.common.dto.CursorPageResponse;
 import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
 import com.twogether.deokhugam.dashboard.dto.response.PopularBookDto;
-import com.twogether.deokhugam.dashboard.dto.response.PopularReviewDto;
 import com.twogether.deokhugam.dashboard.service.PopularBookService;
-import com.twogether.deokhugam.dashboard.service.PopularReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "인기 도서 관리", description = "인기 도서 랭킹 관련 API")
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/books")
 @RequiredArgsConstructor
-public class DashboardController {
+public class PopularBookController {
 
     private final PopularBookService popularBookService;
-    private final PopularReviewService popularReviewService;
 
-    @GetMapping("/books/popular")
+    @Operation(summary = "인기 도서 랭킹 조회", description = "기간별 인기 도서 목록을 커서 페이지네이션 방식으로 조회합니다.")
+    @GetMapping("/popular")
     public CursorPageResponse<PopularBookDto> getPopularBooks(
         @Valid PopularRankingSearchRequest request
     ) {
         return popularBookService.getPopularBooks(request);
-    }
-
-    @GetMapping("/reviews/popular")
-    public CursorPageResponse<PopularReviewDto> getPopularReviews(
-        @Valid PopularRankingSearchRequest request
-    ) {
-        return popularReviewService.getPopularReviews(request);
     }
 }

--- a/src/main/java/com/twogether/deokhugam/dashboard/controller/PopularReviewController.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/controller/PopularReviewController.java
@@ -1,0 +1,30 @@
+package com.twogether.deokhugam.dashboard.controller;
+
+import com.twogether.deokhugam.common.dto.CursorPageResponse;
+import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.dto.response.PopularReviewDto;
+import com.twogether.deokhugam.dashboard.service.PopularReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "인기 리뷰 관리", description = "인기 리뷰 랭킹 관련 API")
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class PopularReviewController {
+
+    private final PopularReviewService popularReviewService;
+
+    @Operation(summary = "인기 리뷰 랭킹 조회", description = "기간별 인기 리뷰 목록을 커서 페이지네이션 방식으로 조회합니다.")
+    @GetMapping("/popular")
+    public CursorPageResponse<PopularReviewDto> getPopularReviews(
+        @Valid PopularRankingSearchRequest request
+    ) {
+        return popularReviewService.getPopularReviews(request);
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/dashboard/controller/PowerUserController.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/controller/PowerUserController.java
@@ -1,0 +1,30 @@
+package com.twogether.deokhugam.dashboard.controller;
+
+import com.twogether.deokhugam.common.dto.CursorPageResponse;
+import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.dto.response.PowerUserDto;
+import com.twogether.deokhugam.dashboard.service.PowerUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "파워 유저 관리", description = "파워 유저 랭킹 관련 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class PowerUserController {
+
+    private final PowerUserService powerUserService;
+
+    @Operation(summary = "파워 유저 랭킹 조회", description = "기간별 파워 유저 목록을 커서 페이지네이션 방식으로 조회합니다.")
+    @GetMapping("/power")
+    public CursorPageResponse<PowerUserDto> getPowerUsers(
+        @Valid PopularRankingSearchRequest request
+    ) {
+        return powerUserService.getPowerUsers(request);
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/dashboard/dto/response/PowerUserDto.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/dto/response/PowerUserDto.java
@@ -1,38 +1,54 @@
 package com.twogether.deokhugam.dashboard.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Schema(description = "Power User Response DTO")
+@Schema(description = "파워 유저 응답 DTO")
 public record PowerUserDto(
 
-    @Schema(description = "User ID")
+    @Schema(description = "사용자 ID")
     UUID userId,
 
-    @Schema(description = "User nickname")
+    @Schema(description = "사용자 닉네임")
     String nickname,
 
-    @Schema(description = "Ranking period")
+    @Schema(description = "랭킹 기간")
     RankingPeriod period,
 
-    @Schema(description = "Timestamp when this ranking was recorded")
+    @Schema(description = "랭킹 생성 시각")
     LocalDateTime createdAt,
 
-    @Schema(description = "Rank in the list")
+    @Schema(description = "순위")
     int rank,
 
-    @Schema(description = "Total activity score")
+    @Schema(description = "총 활동 점수")
     double score,
 
-    @Schema(description = "Total review score sum")
+    @Schema(description = "작성한 리뷰의 총 인기 점수")
     double reviewScoreSum,
 
-    @Schema(description = "Number of likes")
+    @Schema(description = "좋아요 수")
     long likeCount,
 
-    @Schema(description = "Number of comments")
+    @Schema(description = "댓글 수")
     long commentCount
 
-) {}
+) {
+
+    @QueryProjection
+    public PowerUserDto(UUID userId, String nickname, RankingPeriod period, LocalDateTime createdAt, int rank,
+        double score, double reviewScoreSum, long likeCount, long commentCount) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.period = period;
+        this.createdAt = createdAt;
+        this.rank = rank;
+        this.score = score;
+        this.reviewScoreSum = reviewScoreSum;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/dashboard/entity/PowerUserRanking.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/entity/PowerUserRanking.java
@@ -79,7 +79,7 @@ public class PowerUserRanking {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public void assignRank(int rank) {
+    public void assignRank(@Positive int rank) {
         this.rank = rank;
     }
 }

--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingCustomRepository.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingCustomRepository.java
@@ -1,0 +1,11 @@
+package com.twogether.deokhugam.dashboard.repository;
+
+import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.dto.response.PowerUserDto;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface PowerUserRankingCustomRepository {
+
+    List<PowerUserDto> findAllByPeriodWithCursor(PopularRankingSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingCustomRepositoryImpl.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingCustomRepositoryImpl.java
@@ -27,8 +27,8 @@ public class PowerUserRankingCustomRepositoryImpl implements PowerUserRankingCus
 
         return queryFactory
             .select(new QPowerUserDto(
-                u.id,
-                u.nickname,
+                r.user.id,
+                r.nickname,
                 r.period,
                 r.createdAt,
                 r.rank,
@@ -38,7 +38,6 @@ public class PowerUserRankingCustomRepositoryImpl implements PowerUserRankingCus
                 r.commentCount
             ))
             .from(r)
-            .join(r.user, u)
             .where(
                 r.period.eq(request.getPeriod()),
                 ltCursor(request.parseCursor(), request.getAfter(), request.getDirection())

--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingCustomRepositoryImpl.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingCustomRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.twogether.deokhugam.dashboard.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.dto.response.PowerUserDto;
+import com.twogether.deokhugam.dashboard.dto.response.QPowerUserDto;
+import com.twogether.deokhugam.dashboard.entity.QPowerUserRanking;
+import com.twogether.deokhugam.user.entity.QUser;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PowerUserRankingCustomRepositoryImpl implements PowerUserRankingCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PowerUserDto> findAllByPeriodWithCursor(PopularRankingSearchRequest request, Pageable pageable) {
+        QPowerUserRanking r = QPowerUserRanking.powerUserRanking;
+        QUser u = QUser.user;
+
+        return queryFactory
+            .select(new QPowerUserDto(
+                u.id,
+                u.nickname,
+                r.period,
+                r.createdAt,
+                r.rank,
+                r.score,
+                r.reviewScoreSum,
+                r.likeCount,
+                r.commentCount
+            ))
+            .from(r)
+            .join(r.user, u)
+            .where(
+                r.period.eq(request.getPeriod()),
+                ltCursor(request.parseCursor(), request.getAfter(), request.getDirection())
+            )
+            .orderBy(getOrderSpecifiers(request.getDirection()))
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    private BooleanExpression ltCursor(Integer cursor, LocalDateTime after, String direction) {
+        QPowerUserRanking r = QPowerUserRanking.powerUserRanking;
+        if (cursor == null || after == null) return null;
+
+        if ("DESC".equalsIgnoreCase(direction)) {
+            return r.rank.lt(cursor)
+                .or(r.rank.eq(cursor).and(r.createdAt.lt(after)));
+        }
+        return r.rank.gt(cursor)
+            .or(r.rank.eq(cursor).and(r.createdAt.gt(after)));
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(String direction) {
+        QPowerUserRanking r = QPowerUserRanking.powerUserRanking;
+        if ("DESC".equalsIgnoreCase(direction)) {
+            return new OrderSpecifier[] {
+                r.rank.desc(),
+                r.createdAt.desc()
+            };
+        }
+        return new OrderSpecifier[] {
+            r.rank.asc(),
+            r.createdAt.asc()
+        };
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingRepository.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-public interface PowerUserRankingRepository extends JpaRepository<PowerUserRanking, UUID> {
+public interface PowerUserRankingRepository extends JpaRepository<PowerUserRanking, UUID>, PowerUserRankingCustomRepository {
 
     @Modifying
     @Transactional

--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingRepository.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingRepository.java
@@ -16,5 +16,5 @@ public interface PowerUserRankingRepository extends JpaRepository<PowerUserRanki
     @Query("DELETE FROM PowerUserRanking r WHERE r.period = :period")
     void deleteByPeriod(RankingPeriod period);
 
-    List<PowerUserRanking> findByPeriodOrderByRankAsc(RankingPeriod period);
+    List<PowerUserRanking> findAllByPeriod(RankingPeriod period);
 }

--- a/src/main/java/com/twogether/deokhugam/dashboard/service/PowerUserService.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/service/PowerUserService.java
@@ -1,0 +1,10 @@
+package com.twogether.deokhugam.dashboard.service;
+
+import com.twogether.deokhugam.common.dto.CursorPageResponse;
+import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.dto.response.PowerUserDto;
+
+public interface PowerUserService {
+
+    CursorPageResponse<PowerUserDto> getPowerUsers(PopularRankingSearchRequest request);
+}

--- a/src/main/java/com/twogether/deokhugam/dashboard/service/PowerUserServiceImpl.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/service/PowerUserServiceImpl.java
@@ -1,0 +1,59 @@
+package com.twogether.deokhugam.dashboard.service;
+
+import com.twogether.deokhugam.common.dto.CursorPageResponse;
+import com.twogether.deokhugam.common.exception.DeokhugamException;
+import com.twogether.deokhugam.common.exception.ErrorCode;
+import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.dto.response.PowerUserDto;
+import com.twogether.deokhugam.dashboard.repository.PowerUserRankingRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PowerUserServiceImpl implements PowerUserService {
+
+    private final PowerUserRankingRepository powerUserRankingRepository;
+
+    @Override
+    public CursorPageResponse<PowerUserDto> getPowerUsers(PopularRankingSearchRequest request) {
+        validateRequest(request);
+        Pageable pageable = PageRequest.of(0, request.getLimit());
+
+        List<PowerUserDto> content = powerUserRankingRepository
+            .findAllByPeriodWithCursor(request, pageable);
+
+        boolean hasNext = content.size() == request.getLimit();
+        String nextCursor = null;
+        LocalDateTime nextAfter = null;
+
+        if (hasNext) {
+            var last = content.get(content.size() - 1);
+            nextCursor = String.valueOf(last.rank());
+            nextAfter = last.createdAt();
+        }
+
+        return new CursorPageResponse<>(content, nextCursor, nextAfter, request.getLimit(), hasNext);
+    }
+
+    private void validateRequest(PopularRankingSearchRequest request) {
+        if (request.getPeriod() == null) {
+            throw new DeokhugamException(ErrorCode.INVALID_RANKING_PERIOD);
+        }
+
+        String direction = request.getDirection();
+        if (direction == null) {
+            throw new DeokhugamException(ErrorCode.INVALID_DIRECTION);
+        }
+
+        direction = direction.toUpperCase(Locale.ROOT);
+        if (!direction.equals("ASC") && !direction.equals("DESC")) {
+            throw new DeokhugamException(ErrorCode.INVALID_DIRECTION);
+        }
+    }
+}

--- a/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularBookControllerTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularBookControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(PopularBookControllerTest.class)
+@WebMvcTest(PopularBookController.class)
 class PopularBookControllerTest {
 
     @Autowired

--- a/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularBookControllerTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularBookControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(DashboardController.class)
+@WebMvcTest(PopularBookControllerTest.class)
 class PopularBookControllerTest {
 
     @Autowired

--- a/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularBookControllerTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularBookControllerTest.java
@@ -37,11 +37,11 @@ class PopularBookControllerTest {
     void getPopularBooks_success() throws Exception {
         // given
         CursorPageResponse<PopularBookDto> dummyResponse = new CursorPageResponse<>(
-            Collections.emptyList(), // content
-            null,                   // nextCursor
-            null,                   // nextAfter
-            10,                     // size
-            false                   // hasNext
+            Collections.emptyList(),
+            null,
+            null,
+            10,
+            false
         );
 
         Mockito.when(popularBookService.getPopularBooks(any()))

--- a/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularReviewControllerTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularReviewControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(DashboardController.class)
+@WebMvcTest(PopularReviewControllerTest.class)
 class PopularReviewControllerTest {
 
     @Autowired

--- a/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularReviewControllerTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/controller/PopularReviewControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(PopularReviewControllerTest.class)
+@WebMvcTest(PopularReviewController.class)
 class PopularReviewControllerTest {
 
     @Autowired

--- a/src/test/java/com/twogether/deokhugam/dashboard/controller/PowerUserControllerTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/controller/PowerUserControllerTest.java
@@ -1,0 +1,69 @@
+package com.twogether.deokhugam.dashboard.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.twogether.deokhugam.common.dto.CursorPageResponse;
+import com.twogether.deokhugam.common.exception.DeokhugamException;
+import com.twogether.deokhugam.common.exception.ErrorCode;
+import com.twogether.deokhugam.dashboard.dto.response.PowerUserDto;
+import com.twogether.deokhugam.dashboard.service.PowerUserService;
+import java.util.Collections;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PowerUserController.class)
+class PowerUserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PowerUserService powerUserService;
+
+    @Test
+    @DisplayName("파워 유저 목록을 정상적으로 조회할 수 있다")
+    void getPowerUsers_success() throws Exception {
+        // given
+        CursorPageResponse<PowerUserDto> dummyResponse = new CursorPageResponse<>(
+            Collections.emptyList(),
+            null,
+            null,
+            10,
+            false
+        );
+
+        Mockito.when(powerUserService.getPowerUsers(any()))
+            .thenReturn(dummyResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/users/power")
+                .param("period", "DAILY")
+                .param("direction", "ASC")
+                .param("limit", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("잘못된 정렬 방향이면 400을 반환한다")
+    void getPowerUsers_invalidDirection() throws Exception {
+        Mockito.when(powerUserService.getPowerUsers(any()))
+            .thenThrow(new DeokhugamException(ErrorCode.INVALID_DIRECTION));
+
+        mockMvc.perform(get("/api/users/power")
+                .param("period", "DAILY")
+                .param("direction", "WRONG")
+                .param("limit", "10"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("INVALID_DIRECTION"));
+    }
+}

--- a/src/test/java/com/twogether/deokhugam/dashboard/service/PopularBookServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/service/PopularBookServiceTest.java
@@ -79,4 +79,16 @@ class PopularBookServiceTest {
             .isInstanceOf(DeokhugamException.class)
             .hasMessageContaining(ErrorCode.INVALID_RANKING_PERIOD.getMessage());
     }
+
+    @DisplayName("정렬 방향이 null이면 예외를 던진다")
+    @Test
+    void getPopularBooks_nullDirection() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection(null);
+
+        assertThatThrownBy(() -> bookService.getPopularBooks(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.INVALID_DIRECTION.getMessage());
+    }
 }

--- a/src/test/java/com/twogether/deokhugam/dashboard/service/PopularBookServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/service/PopularBookServiceTest.java
@@ -13,9 +13,13 @@ import static org.mockito.Mockito.when;
 import com.twogether.deokhugam.common.exception.DeokhugamException;
 import com.twogether.deokhugam.common.exception.ErrorCode;
 import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.dto.response.PopularBookDto;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PopularBookRankingRepository;
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +38,6 @@ class PopularBookServiceTest {
     @Test
     @DisplayName("정상적으로 인기 도서 목록을 조회할 수 있다")
     void getPopularBooks_success() {
-        // given
         PopularRankingSearchRequest request = new PopularRankingSearchRequest();
         request.setPeriod(RankingPeriod.DAILY);
         request.setDirection("ASC");
@@ -43,10 +46,8 @@ class PopularBookServiceTest {
         when(bookRepository.findAllByPeriodWithCursor(eq(request), any()))
             .thenReturn(Collections.emptyList());
 
-        // when
         var response = bookService.getPopularBooks(request);
 
-        // then
         assertThat(response).isNotNull();
         assertThat(response.getContent()).isEmpty();
         verify(bookRepository, times(1)).findAllByPeriodWithCursor(eq(request), any());
@@ -55,33 +56,17 @@ class PopularBookServiceTest {
     @Test
     @DisplayName("정렬 방향이 잘못되면 예외를 던진다")
     void getPopularBooks_invalidDirection() {
-        // given
         PopularRankingSearchRequest request = new PopularRankingSearchRequest();
         request.setPeriod(RankingPeriod.DAILY);
         request.setDirection("UPWARD");
 
-        // when & then
         assertThatThrownBy(() -> bookService.getPopularBooks(request))
             .isInstanceOf(DeokhugamException.class)
             .hasMessageContaining(ErrorCode.INVALID_DIRECTION.getMessage());
     }
 
     @Test
-    @DisplayName("기간이 null이면 예외를 던진다")
-    void getPopularBooks_nullPeriod() {
-        // given
-        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
-        request.setPeriod(null);
-        request.setDirection("ASC");
-
-        // when & then
-        assertThatThrownBy(() -> bookService.getPopularBooks(request))
-            .isInstanceOf(DeokhugamException.class)
-            .hasMessageContaining(ErrorCode.INVALID_RANKING_PERIOD.getMessage());
-    }
-
     @DisplayName("정렬 방향이 null이면 예외를 던진다")
-    @Test
     void getPopularBooks_nullDirection() {
         PopularRankingSearchRequest request = new PopularRankingSearchRequest();
         request.setPeriod(RankingPeriod.DAILY);
@@ -90,5 +75,96 @@ class PopularBookServiceTest {
         assertThatThrownBy(() -> bookService.getPopularBooks(request))
             .isInstanceOf(DeokhugamException.class)
             .hasMessageContaining(ErrorCode.INVALID_DIRECTION.getMessage());
+    }
+
+    @Test
+    @DisplayName("기간이 null이면 예외를 던진다")
+    void getPopularBooks_nullPeriod() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(null);
+        request.setDirection("ASC");
+
+        assertThatThrownBy(() -> bookService.getPopularBooks(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.INVALID_RANKING_PERIOD.getMessage());
+    }
+
+    @Test
+    @DisplayName("소문자 정렬 방향도 정상 처리된다")
+    void getPopularBooks_lowercaseDirection() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection("asc");
+
+        when(bookRepository.findAllByPeriodWithCursor(eq(request), any()))
+            .thenReturn(Collections.emptyList());
+
+        var result = bookService.getPopularBooks(request);
+
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("조회 결과가 limit보다 작으면 hasNext가 false가 된다")
+    void getPopularBooks_hasNext_false() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection("ASC");
+        request.setLimit(10);
+
+        var dto = new PopularBookDto(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "자바의 정석",
+            "남궁성",
+            "http://thumbnail",
+            RankingPeriod.DAILY,
+            1,
+            99.0,
+            12,
+            4.5,
+            LocalDateTime.now()
+        );
+
+        when(bookRepository.findAllByPeriodWithCursor(eq(request), any()))
+            .thenReturn(List.of(dto));  // size = 1 < limit = 10
+
+        var result = bookService.getPopularBooks(request);
+
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.getNextCursor()).isNull();
+        assertThat(result.getNextAfter()).isNull();
+    }
+
+    @Test
+    @DisplayName("조회 결과가 limit과 같으면 hasNext가 true가 된다")
+    void getPopularBooks_hasNext_true() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection("ASC");
+        request.setLimit(1);
+
+        var dto = new PopularBookDto(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "Clean Code",
+            "로버트 마틴",
+            "http://image",
+            RankingPeriod.DAILY,
+            1,
+            87.0,
+            22,
+            4.8,
+            LocalDateTime.now()
+        );
+
+        when(bookRepository.findAllByPeriodWithCursor(eq(request), any()))
+            .thenReturn(List.of(dto)); // size == limit
+
+        var result = bookService.getPopularBooks(request);
+
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getNextCursor()).isEqualTo("1");
+        assertThat(result.getNextAfter()).isNotNull();
     }
 }

--- a/src/test/java/com/twogether/deokhugam/dashboard/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/service/PopularReviewServiceTest.java
@@ -1,12 +1,15 @@
 package com.twogether.deokhugam.dashboard.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.twogether.deokhugam.common.dto.CursorPageResponse;
+import com.twogether.deokhugam.common.exception.DeokhugamException;
+import com.twogether.deokhugam.common.exception.ErrorCode;
 import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
 import com.twogether.deokhugam.dashboard.dto.response.PopularReviewDto;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
@@ -58,5 +61,17 @@ class PopularReviewServiceTest {
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).bookTitle()).isEqualTo("이펙티브 자바");
+    }
+
+    @DisplayName("정렬 방향이 null이면 예외를 던진다")
+    @Test
+    void getPopularReviews_nullDirection() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection(null);
+
+        assertThatThrownBy(() -> service.getPopularReviews(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.INVALID_DIRECTION.getMessage());
     }
 }

--- a/src/test/java/com/twogether/deokhugam/dashboard/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/service/PopularReviewServiceTest.java
@@ -15,6 +15,7 @@ import com.twogether.deokhugam.dashboard.dto.response.PopularReviewDto;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PopularReviewRankingRepository;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -63,6 +64,18 @@ class PopularReviewServiceTest {
         assertThat(result.getContent().get(0).bookTitle()).isEqualTo("이펙티브 자바");
     }
 
+    @Test
+    @DisplayName("기간이 null이면 예외를 던진다")
+    void getPopularReviews_nullPeriod() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(null);
+        request.setDirection("ASC");
+
+        assertThatThrownBy(() -> service.getPopularReviews(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.INVALID_RANKING_PERIOD.getMessage());
+    }
+
     @DisplayName("정렬 방향이 null이면 예외를 던진다")
     @Test
     void getPopularReviews_nullDirection() {
@@ -73,5 +86,20 @@ class PopularReviewServiceTest {
         assertThatThrownBy(() -> service.getPopularReviews(request))
             .isInstanceOf(DeokhugamException.class)
             .hasMessageContaining(ErrorCode.INVALID_DIRECTION.getMessage());
+    }
+
+    @Test
+    @DisplayName("소문자 정렬 방향도 정상 처리된다")
+    void getPopularReviews_lowercaseDirection() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection("asc");
+
+        when(repository.findAllByPeriodWithCursor(eq(request), any()))
+            .thenReturn(Collections.emptyList());
+
+        var result = service.getPopularReviews(request);
+
+        assertThat(result.getContent()).isEmpty();
     }
 }

--- a/src/test/java/com/twogether/deokhugam/dashboard/service/PowerUserServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/service/PowerUserServiceTest.java
@@ -1,0 +1,81 @@
+package com.twogether.deokhugam.dashboard.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.twogether.deokhugam.common.exception.DeokhugamException;
+import com.twogether.deokhugam.common.exception.ErrorCode;
+import com.twogether.deokhugam.dashboard.dto.request.PopularRankingSearchRequest;
+import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
+import com.twogether.deokhugam.dashboard.repository.PowerUserRankingRepository;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PowerUserServiceTest {
+
+    private PowerUserService powerUserService;
+    private PowerUserRankingRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PowerUserRankingRepository.class);
+        powerUserService = new PowerUserServiceImpl(repository);
+    }
+
+    @Test
+    @DisplayName("정상적으로 파워 유저 목록을 조회할 수 있다")
+    void getPowerUsers_success() {
+        // given
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection("ASC");
+        request.setLimit(10);
+
+        when(repository.findAllByPeriodWithCursor(eq(request), any()))
+            .thenReturn(Collections.emptyList());
+
+        // when
+        var response = powerUserService.getPowerUsers(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getContent()).isEmpty();
+        verify(repository, times(1)).findAllByPeriodWithCursor(eq(request), any());
+    }
+
+    @Test
+    @DisplayName("정렬 방향이 잘못되면 예외를 던진다")
+    void getPowerUsers_invalidDirection() {
+        // given
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection("WRONG");
+
+        // when & then
+        assertThatThrownBy(() -> powerUserService.getPowerUsers(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.INVALID_DIRECTION.getMessage());
+    }
+
+    @Test
+    @DisplayName("기간이 null이면 예외를 던진다")
+    void getPowerUsers_nullPeriod() {
+        // given
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(null);
+        request.setDirection("ASC");
+
+        // when & then
+        assertThatThrownBy(() -> powerUserService.getPowerUsers(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.INVALID_RANKING_PERIOD.getMessage());
+    }
+}

--- a/src/test/java/com/twogether/deokhugam/dashboard/service/PowerUserServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/service/PowerUserServiceTest.java
@@ -78,4 +78,16 @@ class PowerUserServiceTest {
             .isInstanceOf(DeokhugamException.class)
             .hasMessageContaining(ErrorCode.INVALID_RANKING_PERIOD.getMessage());
     }
+
+    @DisplayName("정렬 방향이 null이면 예외를 던진다")
+    @Test
+    void getPowerUsers_nullDirection() {
+        PopularRankingSearchRequest request = new PopularRankingSearchRequest();
+        request.setPeriod(RankingPeriod.DAILY);
+        request.setDirection(null);
+
+        assertThatThrownBy(() -> powerUserService.getPowerUsers(request))
+            .isInstanceOf(DeokhugamException.class)
+            .hasMessageContaining(ErrorCode.INVALID_DIRECTION.getMessage());
+    }
 }

--- a/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingBatchTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingBatchTest.java
@@ -63,6 +63,11 @@ class PowerUserRankingBatchTest {
 
         List<PowerUserRanking> rankings = rankingRepository.findAll();
         assertThat(rankings).isNotEmpty();
+        assertThat(rankings).allMatch(ranking -> ranking.getPeriod() == period);
         assertThat(rankings.get(0).getRank()).isEqualTo(1);
+        for (int i = 0; i < rankings.size(); i++) {
+            assertThat(rankings.get(i).getRank()).isEqualTo(i + 1);
+        }
+        assertThat(rankings).hasSize(2);
     }
 }

--- a/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingWriterTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingWriterTest.java
@@ -50,6 +50,25 @@ class PowerUserRankingWriterTest {
     }
 
     @Test
+    @DisplayName("동점자가 있는 경우 같은 순위를 부여하고 다음 순위를 올바르게 계산한다")
+    void write_tiedScores_assignCorrectRanks() {
+        PowerUserRanking r1 = createRanking("user1", 10.0);
+        PowerUserRanking r2 = createRanking("user2", 10.0); // 동점
+        PowerUserRanking r3 = createRanking("user3", 8.0);
+        PowerUserRanking r4 = createRanking("user4", 8.0);  // 동점
+        PowerUserRanking r5 = createRanking("user5", 6.0);
+        Chunk<PowerUserRanking> chunk = new Chunk<>(List.of(r1, r2, r3, r4, r5));
+
+        writer.write(chunk);
+
+        assertEquals(1, r1.getRank()); // 1위
+        assertEquals(1, r2.getRank()); // 1위 (동점)
+        assertEquals(3, r3.getRank()); // 3위 (2위 건너뜀)
+        assertEquals(3, r4.getRank()); // 3위 (동점)
+        assertEquals(5, r5.getRank()); // 5위 (4위 건너뜀)
+    }
+
+    @Test
     @DisplayName("빈 리스트가 들어오면 예외 발생")
     void write_emptyList_throwsException() {
         Chunk<PowerUserRanking> chunk = new Chunk<>(Collections.emptyList());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#50 

---

## 📝 작업 내용

파워 유저 목록 조회 기능을 구현했습니다.

- 랭킹 기간(RankingPeriod)에 따라 파워 유저 랭킹 정보를 조회하는 API를 구현했습니다.
- PowerUserService, PowerUserController를 분리하여 책임을 명확히 했습니다.
- 정렬 기준은 점수 순 내림차순이며, 최대 10명의 랭킹 데이터를 반환합니다.
- 삭제된 유저 제외, 닉네임 및 점수 포함된 DTO 반환 구조 설계
- Swagger 문서에 API 명세 추가
- 커버리지 확보

### 스크린샷 (선택)

---

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  

### 기능 구현
- [x] 기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [x] 예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
- [x] 테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [x] 실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)

---

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 파워 유저 랭킹 조회 API가 추가되어, 기간별 파워 유저 목록을 커서 기반 페이지네이션 방식으로 확인할 수 있습니다.
  * 인기 도서 랭킹 조회 API가 별도의 엔드포인트로 분리되어 제공됩니다.

* **버그 수정**
  * 없음

* **문서화**
  * Swagger(OpenAPI) 문서가 한글로 개선되고, 각 컨트롤러 및 엔드포인트에 상세 설명이 추가되었습니다.

* **테스트**
  * 파워 유저 및 인기 도서/리뷰 랭킹 관련 컨트롤러와 서비스에 대한 단위 테스트 및 통합 테스트가 추가되었습니다.
  * 커서 페이지네이션, 입력값 검증, 예외 상황 등 다양한 케이스가 테스트에 반영되었습니다.

* **리팩터링**
  * 인기 리뷰 및 인기 도서 컨트롤러가 분리되어 구조가 명확해졌습니다.
  * 파워 유저 랭킹 관련 코드가 도메인 별로 정리되고, 검증 어노테이션이 적용되어 데이터 무결성이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->