### PR TITLE
Feature: 알림 단건 읽음 처리 기능 구현

### DIFF
--- a/src/main/java/com/twogether/deokhugam/common/exception/ErrorCode.java
+++ b/src/main/java/com/twogether/deokhugam/common/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     INVALID_RANKING_PERIOD(HttpStatus.BAD_REQUEST, "지원하지 않는 랭킹 기간입니다."),
     INVALID_DIRECTION(HttpStatus.BAD_REQUEST, "정렬 방향은 ASC 또는 DESC만 가능합니다."),
 
+    // Notification 관련 에러 코드
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림이 존재하지 않거나 접근 권한이 없습니다."),
+
     // Cursor 관련 에러 코드
     INVALID_CURSOR(HttpStatus.BAD_REQUEST, "커서 정보가 올바르지 않습니다."),
 

--- a/src/main/java/com/twogether/deokhugam/notification/controller/NotificationController.java
+++ b/src/main/java/com/twogether/deokhugam/notification/controller/NotificationController.java
@@ -8,11 +8,13 @@ import com.twogether.deokhugam.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class NotificationController {
 
     private final NotificationQueryService notificationQueryService;
@@ -40,6 +43,7 @@ public class NotificationController {
         @Parameter(description = "보조 커서 (정확한 정렬을 위한 createdAt 값)", example = "2025-07-20T19:00:00")
         @RequestParam(required = false) LocalDateTime after,
 
+        @Min(value = 1, message = "limit은 1 이상의 정수")
         @Parameter(description = "페이지 크기", example = "20")
         @RequestParam(required = false) Integer limit,
 

--- a/src/main/java/com/twogether/deokhugam/notification/controller/NotificationController.java
+++ b/src/main/java/com/twogether/deokhugam/notification/controller/NotificationController.java
@@ -2,14 +2,21 @@ package com.twogether.deokhugam.notification.controller;
 
 import com.twogether.deokhugam.common.dto.CursorPageResponse;
 import com.twogether.deokhugam.notification.dto.NotificationDto;
+import com.twogether.deokhugam.notification.dto.NotificationUpdateRequest;
 import com.twogether.deokhugam.notification.service.NotificationQueryService;
+import com.twogether.deokhugam.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotificationQueryService notificationQueryService;
+    private final NotificationService notificationService;
 
     @Operation(summary = "알림 목록 조회", description = "사용자의 알림 목록을 커서 기반으로 조회합니다. 최신 알림부터 정렬됩니다.")
     @GetMapping("/api/notifications")
@@ -39,5 +47,22 @@ public class NotificationController {
         @RequestParam(required = false) Sort.Direction direction
     ) {
         return notificationQueryService.getNotifications(userId, cursor, after, limit, direction);
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림의 확인 여부를 true 또는 false로 수정합니다.")
+    @PatchMapping("/api/notifications/{notificationId}")
+    public ResponseEntity<NotificationDto> updateNotification(
+        @Parameter(description = "알림 ID", required = true)
+        @PathVariable UUID notificationId,
+
+        @Parameter(description = "요청자 ID", required = true)
+        @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+
+        @Valid @RequestBody NotificationUpdateRequest request
+    ) {
+        NotificationDto updated = notificationService.updateConfirmedStatus(
+            notificationId, requestUserId, request.confirmed()
+        );
+        return ResponseEntity.ok(updated);
     }
 }

--- a/src/main/java/com/twogether/deokhugam/notification/dto/NotificationUpdateRequest.java
+++ b/src/main/java/com/twogether/deokhugam/notification/dto/NotificationUpdateRequest.java
@@ -3,11 +3,11 @@ package com.twogether.deokhugam.notification.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "Notification update request DTO")
+@Schema(description = "알림 확인 여부 수정 요청 DTO")
 public record NotificationUpdateRequest(
 
     @NotNull
-    @Schema(description = "Confirmed status")
+    @Schema(description = "알림 확인 여부")
     Boolean confirmed
 
 ) {}

--- a/src/main/java/com/twogether/deokhugam/notification/entity/Notification.java
+++ b/src/main/java/com/twogether/deokhugam/notification/entity/Notification.java
@@ -70,4 +70,12 @@ public class Notification {
     public void confirm() {
         this.confirmed = true;
     }
+
+    public void setConfirmed(boolean confirmed) {
+        this.confirmed = confirmed;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/com/twogether/deokhugam/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/twogether/deokhugam/notification/exception/NotificationNotFoundException.java
@@ -1,8 +1,11 @@
 package com.twogether.deokhugam.notification.exception;
 
-public class NotificationNotFoundException extends RuntimeException {
+import com.twogether.deokhugam.common.exception.DeokhugamException;
+import com.twogether.deokhugam.common.exception.ErrorCode;
 
-    public NotificationNotFoundException(String message) {
-        super(message);
+public class NotificationNotFoundException extends DeokhugamException {
+
+    public NotificationNotFoundException() {
+        super(ErrorCode.NOTIFICATION_NOT_FOUND);
     }
 }

--- a/src/main/java/com/twogether/deokhugam/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/twogether/deokhugam/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,8 @@
+package com.twogether.deokhugam.notification.exception;
+
+public class NotificationNotFoundException extends RuntimeException {
+
+    public NotificationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/twogether/deokhugam/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.twogether.deokhugam.notification.repository;
 import com.twogether.deokhugam.notification.entity.Notification;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,4 +34,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
         @Param("userId") UUID userId,
         Pageable pageable
     );
+
+    Optional<Notification> findByIdAndUserId(UUID id, UUID userId);
 }

--- a/src/main/java/com/twogether/deokhugam/notification/service/NotificationService.java
+++ b/src/main/java/com/twogether/deokhugam/notification/service/NotificationService.java
@@ -9,6 +9,7 @@ import com.twogether.deokhugam.review.entity.Review;
 import com.twogether.deokhugam.user.entity.User;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -67,7 +68,7 @@ public class NotificationService {
             .orElseThrow(NotificationNotFoundException::new);
 
         notification.setConfirmed(confirmed);
-        notification.setUpdatedAt(Instant.now());
+        notification.setUpdatedAt(LocalDateTime.now());
 
         return notificationMapper.toDto(notification);
     }

--- a/src/main/java/com/twogether/deokhugam/notification/service/NotificationService.java
+++ b/src/main/java/com/twogether/deokhugam/notification/service/NotificationService.java
@@ -1,10 +1,15 @@
 package com.twogether.deokhugam.notification.service;
 
+import com.twogether.deokhugam.notification.dto.NotificationDto;
 import com.twogether.deokhugam.notification.entity.Notification;
+import com.twogether.deokhugam.notification.exception.NotificationNotFoundException;
+import com.twogether.deokhugam.notification.mapper.NotificationMapper;
 import com.twogether.deokhugam.notification.repository.NotificationRepository;
 import com.twogether.deokhugam.review.entity.Review;
 import com.twogether.deokhugam.user.entity.User;
 import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
 
     /**
      * 좋아요 알림 생성
@@ -50,5 +56,19 @@ public class NotificationService {
         String content = "나의 리뷰가 인기 리뷰 순위에 진입했습니다!";
         Notification notification = Notification.of(receiver, review, content);
         notificationRepository.save(notification);
+    }
+
+    /**
+     * 알림 단건 읽음 처리
+     */
+    @Transactional
+    public NotificationDto updateConfirmedStatus(UUID notificationId, UUID userId, boolean confirmed) {
+        Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+            .orElseThrow(NotificationNotFoundException::new);
+
+        notification.setConfirmed(confirmed);
+        notification.setUpdatedAt(Instant.now());
+
+        return notificationMapper.toDto(notification);
     }
 }

--- a/src/main/java/com/twogether/deokhugam/notification/service/NotificationService.java
+++ b/src/main/java/com/twogether/deokhugam/notification/service/NotificationService.java
@@ -68,7 +68,6 @@ public class NotificationService {
             .orElseThrow(NotificationNotFoundException::new);
 
         notification.setConfirmed(confirmed);
-        notification.setUpdatedAt(LocalDateTime.now());
 
         return notificationMapper.toDto(notification);
     }

--- a/src/test/java/com/twogether/deokhugam/notification/NotificationServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/notification/NotificationServiceTest.java
@@ -110,7 +110,6 @@ class NotificationServiceTest {
         // then
         assertThat(result).isEqualTo(dto);
         verify(notification).setConfirmed(true);
-        verify(notification).setUpdatedAt(any(LocalDateTime.class));
     }
 
     @Test

--- a/src/test/java/com/twogether/deokhugam/notification/NotificationServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/notification/NotificationServiceTest.java
@@ -1,5 +1,7 @@
 package com.twogether.deokhugam.notification;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -7,11 +9,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.twogether.deokhugam.notification.dto.NotificationDto;
 import com.twogether.deokhugam.notification.entity.Notification;
+import com.twogether.deokhugam.notification.exception.NotificationNotFoundException;
+import com.twogether.deokhugam.notification.mapper.NotificationMapper;
 import com.twogether.deokhugam.notification.repository.NotificationRepository;
 import com.twogether.deokhugam.notification.service.NotificationService;
 import com.twogether.deokhugam.review.entity.Review;
 import com.twogether.deokhugam.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +27,7 @@ class NotificationServiceTest {
 
     private NotificationService notificationService;
     private NotificationRepository notificationRepository;
+    private NotificationMapper notificationMapper;
 
     private User writer;
     private User otherUser;
@@ -28,7 +36,8 @@ class NotificationServiceTest {
     @BeforeEach
     void setUp() {
         notificationRepository = mock(NotificationRepository.class);
-        notificationService = new NotificationService(notificationRepository);
+        notificationMapper = mock(NotificationMapper.class);
+        notificationService = new NotificationService(notificationRepository, notificationMapper);
 
         // 작성자
         writer = mock(User.class);
@@ -80,5 +89,42 @@ class NotificationServiceTest {
         notificationService.createLikeNotification(writer, review);
 
         verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void 알림_확인_상태_변경_성공() {
+        // given
+        UUID notificationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        Notification notification = mock(Notification.class);
+        NotificationDto dto = mock(NotificationDto.class);
+
+        when(notificationRepository.findByIdAndUserId(notificationId, userId))
+            .thenReturn(Optional.of(notification));
+        when(notificationMapper.toDto(notification)).thenReturn(dto);
+
+        // when
+        NotificationDto result = notificationService.updateConfirmedStatus(notificationId, userId, true);
+
+        // then
+        assertThat(result).isEqualTo(dto);
+        verify(notification).setConfirmed(true);
+        verify(notification).setUpdatedAt(any(LocalDateTime.class));
+    }
+
+    @Test
+    void 알림이_없으면_예외를_던진다() {
+        // given
+        UUID notificationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        when(notificationRepository.findByIdAndUserId(notificationId, userId))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+            notificationService.updateConfirmedStatus(notificationId, userId, true)
+        ).isInstanceOf(NotificationNotFoundException.class);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#28 

---

## 📝 작업 내용

알림 단건 읽음 처리 기능을 구현하였습니다.

- 특정 알림의 확인 여부를 true/false로 수정할 수 있는 PATCH API를 추가했습니다.
- 본인의 알림만 수정할 수 있도록 권한 검증 로직을 추가했습니다.

### 스크린샷 (선택)

---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다  

### 기능 구현
- [ ] 기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [ ] 예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
- [ ] 테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [ ] 실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)

---

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 알림의 읽음(확인) 상태를 수정하는 PATCH API가 추가되었습니다.
  * 알림 읽음 상태 변경 시, 알림이 없을 경우 404 오류가 반환됩니다.

* **버그 수정**
  * 요청 헤더 누락, 파라미터 타입 오류, 제약 조건 위반 시 상세 오류 메시지가 반환됩니다.

* **문서화**
  * 알림 상태 수정 요청 DTO의 Swagger 설명이 한글로 개선되었습니다.

* **테스트**
  * 알림 읽음 상태 변경 API 및 서비스에 대한 단위 테스트와 예외 상황 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->