### PR TITLE
Fix : ReviewRepository updateBookReviewStats 메서드 복구

### DIFF
--- a/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
@@ -16,7 +16,15 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
 
     boolean existsByUserIdAndBookId(UUID userId, UUID bookId);
     boolean existsByUserIdAndBookIdAndIsDeletedFalse(UUID userId, UUID bookId);
-
+    
+    @Modifying
+    @Query("""
+    UPDATE Book b SET 
+        b.reviewCount = (SELECT COUNT(r) FROM Review r WHERE r.book.id = :bookId AND r.isDeleted = false),
+        b.rating = (SELECT COALESCE(AVG(r.rating * 1.0), 0) FROM Review r WHERE r.book.id = :bookId AND r.isDeleted = false)
+    WHERE b.id = :bookId
+""")
+    void updateBookReviewStats(@Param("bookId") UUID bookId);
 
     @Modifying
     @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1, r.updatedAt = CURRENT_TIMESTAMP WHERE r.id = :reviewId")


### PR DESCRIPTION
충돌 발생과정에서 실수로 삭제된 메서드 복구

## 📝 작업 내용

리뷰등록,삭제 시 도서 엔티티에서 reviewCount와 rating 업데이트 메서드 관련 쿼리 복구

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다  

---

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 도서의 리뷰 통계(리뷰 수, 평점)를 최신 상태로 갱신하는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->