### PR TITLE
Feat: 도서 Service 명칭 LocalBookService ->BookServiceImpl로 변경 및 리뷰변동 반영 메서드 통합

### DIFF
--- a/src/main/java/com/twogether/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/twogether/deokhugam/book/service/BookService.java
@@ -18,5 +18,4 @@ public interface BookService {
     BookDto updateBook(UUID bookId, BookUpdateRequest request, MultipartFile thumbnailImg);
     void deleteBook(UUID bookId);
     void deleteBookHard(UUID bookId);
-	void updateReviewStats(UUID bookId);
 }

--- a/src/main/java/com/twogether/deokhugam/book/service/BookServiceImpl.java
+++ b/src/main/java/com/twogether/deokhugam/book/service/BookServiceImpl.java
@@ -27,7 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class LocalBookService implements BookService {
+public class BookServiceImpl implements BookService {
 
     private final BookRepository bookRepository;
     private final ReviewRepository reviewRepository;

--- a/src/main/java/com/twogether/deokhugam/book/service/BookServiceImpl.java
+++ b/src/main/java/com/twogether/deokhugam/book/service/BookServiceImpl.java
@@ -210,16 +210,4 @@ public class BookServiceImpl implements BookService {
         }
         bookRepository.deleteById(bookId);
     }
-
-    @Override
-    public void updateReviewStats(UUID bookId){
-        Book book = bookRepository.findById(bookId).orElseThrow(BookNotFoundException::new);
-
-        Object[] stats = (Object[]) reviewRepository.getReviewStats(bookId); // ✅ 캐스팅
-        int count = ((Number) stats[0]).intValue();
-        float average = ((Number) stats[1]).floatValue();
-
-        book.setReviewCount(count);
-        book.setRating(average);
-    }
 }

--- a/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
@@ -17,7 +17,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
     boolean existsByUserIdAndBookId(UUID userId, UUID bookId);
     boolean existsByUserIdAndBookIdAndIsDeletedFalse(UUID userId, UUID bookId);
 
-
     @Modifying
     @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1, r.updatedAt = CURRENT_TIMESTAMP WHERE r.id = :reviewId")
     void incrementCommentCount(@Param("reviewId") UUID reviewId);

--- a/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
+++ b/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
@@ -82,7 +82,6 @@ public class BasicReviewService implements ReviewService{
         bookRepository.save(reviewedBook);
 
         reviewLikeRepository.save(reviewLike);
-        bookService.updateReviewStats(request.bookId());
         log.info("[BasicReviewService] 리뷰 등록 성공");
 
         return reviewMapper.toDto(review, false);
@@ -189,7 +188,6 @@ public class BasicReviewService implements ReviewService{
         bookRepository.save(reviewedBook);
 
         reviewRepository.save(review);
-        bookService.updateReviewStats(review.getBook().getId());
 
         log.info("[BasicReviewService]: 리뷰 논리 삭제 완료");
     }

--- a/src/test/java/com/twogether/deokhugam/book/BookServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/book/BookServiceTest.java
@@ -9,7 +9,7 @@ import com.twogether.deokhugam.book.dto.BookDto;
 import com.twogether.deokhugam.book.dto.request.BookCreateRequest;
 import com.twogether.deokhugam.book.entity.Book;
 import com.twogether.deokhugam.book.repository.BookRepository;
-import com.twogether.deokhugam.book.service.LocalBookService;
+import com.twogether.deokhugam.book.service.BookServiceImpl;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ class BookServiceTest {
   private BookRepository bookRepository;
 
   @InjectMocks
-  private LocalBookService bookService;
+  private BookServiceImpl bookService;
 
   @Test
   @DisplayName("ISBN,썸네일 없이 도서 정보를 등록")


### PR DESCRIPTION
## 📝 작업 내용

- BookService 구현체 BookServiceImpl로 변경
- 리뷰등록,삭제시 변경내역 업데이트 메서드 삭제

### 스크린샷 (선택)

---

## ✅ PR Checklist

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다  

### 기능 구현
- [ ] 기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [ ] 예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
- [ ] 실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)

---

## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩터링**
  * BookService 인터페이스에서 리뷰 통계 업데이트 메서드가 제거되었습니다.
  * 관련 구현체의 클래스명이 변경되고, 불필요한 리뷰 통계 업데이트 메서드가 삭제되었습니다.
  * 리뷰 서비스에서 중복된 리뷰 통계 업데이트 호출이 제거되었습니다.

* **테스트**
  * 테스트 코드에서 서비스 클래스명이 변경된 부분이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->