### PR TITLE
Fix: 쿼리메서드에서 updatedAt을 수정하는 부분 제외

### DIFF
--- a/src/main/java/com/twogether/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/twogether/deokhugam/review/entity/Review.java
@@ -93,8 +93,8 @@ public class Review {
         this.likeCount = likeCount;
     }
 
-    public void updateCommentCount(int commentCount){
-        this.commentCount = commentCount;
+    public void updateUpdatedAt(){
+        this.updatedAt = Instant.now();
     }
 
     public void updateReview(String content, int rating){

--- a/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
@@ -15,12 +15,16 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
 
     boolean existsByUserIdAndBookIdAndIsDeletedFalse(UUID userId, UUID bookId);
 
+//    @Modifying
+//    @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1, r.updatedAt = CURRENT_TIMESTAMP WHERE r.id = :reviewId")
+//    void incrementCommentCount(@Param("reviewId") UUID reviewId);
+
     @Modifying
-    @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1, r.updatedAt = CURRENT_TIMESTAMP WHERE r.id = :reviewId")
+    @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1 WHERE r.id = :reviewId")
     void incrementCommentCount(@Param("reviewId") UUID reviewId);
 
     @Modifying
-    @Query("UPDATE Review r SET r.commentCount = r.commentCount - 1, r.updatedAt = CURRENT_TIMESTAMP WHERE r.id = :reviewId")
+    @Query("UPDATE Review r SET r.commentCount = r.commentCount - 1 WHERE r.id = :reviewId")
     void decrementCommentCount(@Param("reviewId") UUID reviewId);
 
 }

--- a/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
@@ -17,10 +17,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
     boolean existsByUserIdAndBookId(UUID userId, UUID bookId);
     boolean existsByUserIdAndBookIdAndIsDeletedFalse(UUID userId, UUID bookId);
 
-//    @Modifying
-//    @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1, r.updatedAt = CURRENT_TIMESTAMP WHERE r.id = :reviewId")
-//    void incrementCommentCount(@Param("reviewId") UUID reviewId);
-
     @Modifying
     @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1 WHERE r.id = :reviewId")
     void incrementCommentCount(@Param("reviewId") UUID reviewId);


### PR DESCRIPTION
## 🐛 Problem

리뷰 테이블 구조와 관련된 이슈

### 에러 로그

---

## 🔍 Root Cause
- 댓글 생성, 삭제 시에 ReviewRepository의 쿼리 메서드 이용해서 Review의 commentCount을 변경하는데
- 이 과정에서 쿼리 메서드에 작성한 updatedAt 업뎃 쿼리로 인해 Instant 변환 타입 오류 발생

## ✅ Solution
쿼리 메서드에서 시간을 업데이트하는 로직 제외하고 entity에서 updateUpdatedAt 메서드 만들어서 사용

### 변경사항
- 쿼리 메서드에 시간을 업데이트하는 로직 제외
= entity에 updateUpdatedAt 메서드 추가

---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  
- [x] 변경 사항에 대한 테스트를 했습니다 (버그 수정/기능에 대한 테스트)

---

## 📚 Additional Notes


## 🔗 Reference

## Summary by CodeRabbit
- 버그 수정
    - 댓글 수가 변경될 때마다 리뷰의 마지막 수정 시간이 정확하게 갱신되도록 개선되었습니다.

- 기타
    - 댓글 수 변경 시 리뷰 정보를 명확하게 갱신하여 데이터 일관성이 향상되었습니다.
