### PR TITLE
Fix: commentCount 저장 안 되는 문제 해결

### DIFF
--- a/src/main/java/com/twogether/deokhugam/comments/service/CommentService.java
+++ b/src/main/java/com/twogether/deokhugam/comments/service/CommentService.java
@@ -54,8 +54,6 @@ public class CommentService {
         Comment saved = commentRepository.save(entity);
 
         reviewRepository.incrementCommentCount(request.reviewId());
-        review.updateUpdatedAt();
-        reviewRepository.save(review);
 
         // 알림 생성 조건 추가 (자기 댓글은 제외)
         if (!user.getId().equals(review.getUser().getId())) {
@@ -96,12 +94,7 @@ public class CommentService {
         if (Boolean.TRUE.equals(comment.getIsDeleted())) {
             throw new IllegalStateException("이미 삭제된 댓글입니다.");
         }
-        Review review = reviewRepository.findById(comment.getReview().getId())
-                .orElseThrow(() -> new ReviewNotFoundException(comment.getReview().getId()));
-
-        reviewRepository.decrementCommentCount(review.getId());
-        review.updateUpdatedAt();
-        reviewRepository.save(review);
+        reviewRepository.decrementCommentCount(comment.getReview().getId());
 
         commentRepository.logicalDeleteById(commentId);
     }
@@ -116,12 +109,7 @@ public class CommentService {
 
         if (!comment.getIsDeleted()) {
             // 집계에 포함되었던 댓글이므로 -1 필요
-            Review review = reviewRepository.findById(comment.getReview().getId())
-                    .orElseThrow(() -> new ReviewNotFoundException(comment.getReview().getId()));
-
-            reviewRepository.decrementCommentCount(review.getId());
-            review.updateUpdatedAt();
-            reviewRepository.save(review);
+            reviewRepository.decrementCommentCount(comment.getReview().getId());
         }
 
         commentRepository.deleteById(commentId);

--- a/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
@@ -24,6 +24,4 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
     @Modifying
     @Query("UPDATE Review r SET r.commentCount = r.commentCount - 1 WHERE r.id = :reviewId")
     void decrementCommentCount(@Param("reviewId") UUID reviewId);
-
-
 }


### PR DESCRIPTION
## 🐛 Problem

DB와 영속성 컨테이너 상의 객체와의 차이로 인한 오류

### 에러 로그

---

## 🔍 Root Cause
- JPQL 사용 시 데이터베이스에 바로 저장, JPA의 save메서드를 쓰면 영속성 컨테이너에 있던 Review객체가 덮어씌워짐

## ✅ Solution
updatedAt을 저장하는 대신 댓글 개수를 저장할 수 있도록 선택

### 변경사항
- CommentService의 댓글 생성, 삭제 메서드의 reviewRepository.save 호출 부분 제거
---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  
- [x] 변경 사항에 대한 테스트를 했습니다 (버그 수정/기능에 대한 테스트)

---

## 📚 Additional Notes


## 🔗 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 댓글 수 변경 시 내부 처리 방식을 간소화하여 성능과 유지보수성을 개선했습니다.  
* **Style**
  * 코드 내 불필요한 공백을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->