### PR TITLE
Feature: 읽은 알림 자동 삭제 배치 구현

### DIFF
--- a/src/main/java/com/twogether/deokhugam/config/NotificationCleanupJobConfig.java
+++ b/src/main/java/com/twogether/deokhugam/config/NotificationCleanupJobConfig.java
@@ -1,9 +1,8 @@
 package com.twogether.deokhugam.config;
 
 import com.twogether.deokhugam.notification.batch.reader.JpaNotificationReader;
+import com.twogether.deokhugam.notification.batch.writer.NotificationDeleteWriter;
 import com.twogether.deokhugam.notification.entity.Notification;
-import com.twogether.deokhugam.notification.repository.NotificationRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -11,7 +10,6 @@ import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.database.JpaPagingItemReader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,9 +19,9 @@ import org.springframework.transaction.PlatformTransactionManager;
 @RequiredArgsConstructor
 public class NotificationCleanupJobConfig {
 
-    private final NotificationRepository notificationRepository;
-    private final PlatformTransactionManager transactionManager;
     private final JpaNotificationReader jpaNotificationReader;
+    private final NotificationDeleteWriter notificationDeleteWriter;
+    private final PlatformTransactionManager transactionManager;
 
     @Bean
     public Job notificationCleanupJob(JobRepository jobRepository) {
@@ -38,17 +36,12 @@ public class NotificationCleanupJobConfig {
         return new StepBuilder("notificationCleanupStep", jobRepository)
             .<Notification, Notification>chunk(100, transactionManager)
             .reader(notificationReader())
-            .writer(notificationWriter())
+            .writer(notificationDeleteWriter)
             .build();
     }
 
     @Bean
     public JpaPagingItemReader<Notification> notificationReader() {
         return jpaNotificationReader.create();
-    }
-
-    @Bean
-    public ItemWriter<Notification> notificationWriter() {
-        return notifications -> notificationRepository.deleteAllInBatch((List<Notification>) notifications);
     }
 }

--- a/src/main/java/com/twogether/deokhugam/config/NotificationCleanupJobConfig.java
+++ b/src/main/java/com/twogether/deokhugam/config/NotificationCleanupJobConfig.java
@@ -1,0 +1,70 @@
+package com.twogether.deokhugam.config;
+
+import com.twogether.deokhugam.notification.entity.Notification;
+import com.twogether.deokhugam.notification.repository.NotificationRepository;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class NotificationCleanupJobConfig {
+
+    private final NotificationRepository notificationRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    @Bean
+    public Job notificationCleanupJob(JobRepository jobRepository) {
+        return new JobBuilder("notificationCleanupJob", jobRepository)
+            .start(notificationCleanupStep(jobRepository))
+            .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step notificationCleanupStep(JobRepository jobRepository) {
+        return new StepBuilder("notificationCleanupStep", jobRepository)
+            .<Notification, Notification>chunk(100, transactionManager)
+            .reader(notificationReader())
+            .writer(notificationWriter())
+            .build();
+    }
+
+    @Bean
+    public JpaPagingItemReader<Notification> notificationReader() {
+        LocalDateTime cutoff = LocalDateTime.now().minus(7, ChronoUnit.DAYS);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("cutoff", cutoff);
+
+        return new JpaPagingItemReaderBuilder<Notification>()
+            .name("notificationReader")
+            .entityManagerFactory(notificationRepository.getEntityManager().getEntityManagerFactory())
+            .queryString("""
+                    SELECT n FROM Notification n
+                    WHERE n.confirmed = true AND n.updatedAt < :cutoff
+                """)
+            .parameterValues(params)
+            .pageSize(100)
+            .build();
+    }
+
+    @Bean
+    public ItemWriter<Notification> notificationWriter() {
+        return notifications -> notificationRepository.deleteAllInBatch(notifications);
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularBookRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularBookRankingScheduler.java
@@ -10,7 +10,6 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +23,7 @@ public class PopularBookRankingScheduler {
     private final Job popularBookRankingJob;
 
     //@Scheduled(initialDelay = 1000, fixedDelay = Long.MAX_VALUE) // application 실행 시 즉시 배치 (테스트용)
-    @Scheduled(cron = "${batch.popular-book-ranking.cron}")
+    @Scheduled(cron = "${batch.popular-book-ranking.cron:0 0 0 * * *}")
     public void runRankingJob() {
         String jobName = "popularBookRankingJob";
         String requestId = UUID.randomUUID().toString();

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularReviewRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularReviewRankingScheduler.java
@@ -10,7 +10,6 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +23,7 @@ public class PopularReviewRankingScheduler {
     private final Job popularReviewRankingJob;
 
     //@Scheduled(initialDelay = 1000, fixedDelay = Long.MAX_VALUE) // application 실행 시 즉시 배치 (테스트용)
-    @Scheduled(cron = "${batch.popular-review-ranking.cron}")
+    @Scheduled(cron = "${batch.popular-review-ranking.cron:0 5 0 * * *}")
     public void runRankingJob() {
         String jobName = "popularReviewRankingJob";
         String requestId = UUID.randomUUID().toString();

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PowerUserRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PowerUserRankingScheduler.java
@@ -25,7 +25,7 @@ public class PowerUserRankingScheduler {
     private final PowerUserRankingRepository powerUserRankingRepository;
 
     //@Scheduled(initialDelay = 1000, fixedDelay = Long.MAX_VALUE) // application 실행 시 즉시 배치 (테스트용)
-    @Scheduled(cron = "${batch.power-user-ranking.cron}")
+    @Scheduled(cron = "${batch.power-user-ranking.cron:0 10 0 * * *}")
     public void runRankingJob() {
         String jobName = "powerUserRankingJob";
         String requestId = UUID.randomUUID().toString();

--- a/src/main/java/com/twogether/deokhugam/notification/batch/reader/JpaNotificationReader.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/reader/JpaNotificationReader.java
@@ -1,0 +1,39 @@
+package com.twogether.deokhugam.notification.batch.reader;
+
+import com.twogether.deokhugam.notification.entity.Notification;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JpaNotificationReader {
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    public JpaNotificationReader(EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    public JpaPagingItemReader<Notification> create() {
+        LocalDateTime cutoff = LocalDateTime.now().minus(7, ChronoUnit.DAYS);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("cutoff", cutoff);
+
+        return new JpaPagingItemReaderBuilder<Notification>()
+            .name("jpaNotificationReader")
+            .entityManagerFactory(entityManagerFactory)
+            .queryString("""
+                    SELECT n FROM Notification n
+                    WHERE n.confirmed = true AND n.updatedAt < :cutoff
+                """)
+            .parameterValues(params)
+            .pageSize(100)
+            .build();
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
@@ -1,0 +1,29 @@
+package com.twogether.deokhugam.notification.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationCleanupScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job notificationCleanupJob;
+    
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runNotificationCleanupJob() {
+        try {
+            log.info("[Batch] 읽은 알림 삭제 배치 시작");
+            jobLauncher.run(notificationCleanupJob, new JobParameters());
+            log.info("[Batch] 읽은 알림 삭제 배치 완료");
+        } catch (Exception e) {
+            log.error("[Batch] 읽은 알림 삭제 배치 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
@@ -4,26 +4,35 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "batch.notification-cleanup.enabled", havingValue = "true")
 public class NotificationCleanupScheduler {
 
     private final JobLauncher jobLauncher;
     private final Job notificationCleanupJob;
-    
-    @Scheduled(cron = "0 0 0 * * *")
+
+    @Scheduled(cron = "${batch.notification-cleanup.cron:0 0 1 * * *}")
     public void runNotificationCleanupJob() {
         try {
-            log.info("[Batch] 읽은 알림 삭제 배치 시작");
-            jobLauncher.run(notificationCleanupJob, new JobParameters());
-            log.info("[Batch] 읽은 알림 삭제 배치 완료");
+            log.info("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 시작");
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+            jobLauncher.run(notificationCleanupJob, jobParameters);
+
+            log.info("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 완료");
         } catch (Exception e) {
-            log.error("[Batch] 읽은 알림 삭제 배치 실패", e);
+            log.error("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 실행 중 오류 발생", e);
         }
     }
 }

--- a/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
@@ -19,7 +19,7 @@ public class NotificationCleanupScheduler {
     private final JobLauncher jobLauncher;
     private final Job notificationCleanupJob;
 
-    @Scheduled(cron = "${batch.notification-cleanup.cron:0 0 1 * * *}")
+    @Scheduled(cron = "${batch.notification-cleanup.cron:0 15 0 * * *}")
     public void runNotificationCleanupJob() {
         try {
             log.info("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 시작");

--- a/src/main/java/com/twogether/deokhugam/notification/batch/writer/NotificationDeleteWriter.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/writer/NotificationDeleteWriter.java
@@ -2,8 +2,10 @@ package com.twogether.deokhugam.notification.batch.writer;
 
 import com.twogether.deokhugam.notification.entity.Notification;
 import com.twogether.deokhugam.notification.repository.NotificationRepository;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
@@ -14,8 +16,9 @@ public class NotificationDeleteWriter implements ItemWriter<Notification> {
     private final NotificationRepository notificationRepository;
 
     @Override
-    public void write(List<? extends Notification> notifications) {
-        if (!notifications.isEmpty()) {
+    public void write(Chunk<? extends Notification> chunk) {
+        if (!chunk.isEmpty()) {
+            List<Notification> notifications = new ArrayList<>(chunk.getItems());
             notificationRepository.deleteAllInBatch(notifications);
         }
     }

--- a/src/main/java/com/twogether/deokhugam/notification/batch/writer/NotificationDeleteWriter.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/writer/NotificationDeleteWriter.java
@@ -1,0 +1,22 @@
+package com.twogether.deokhugam.notification.batch.writer;
+
+import com.twogether.deokhugam.notification.entity.Notification;
+import com.twogether.deokhugam.notification.repository.NotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationDeleteWriter implements ItemWriter<Notification> {
+
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    public void write(List<? extends Notification> notifications) {
+        if (!notifications.isEmpty()) {
+            notificationRepository.deleteAllInBatch(notifications);
+        }
+    }
+}

--- a/src/main/java/com/twogether/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/twogether/deokhugam/notification/repository/NotificationRepository.java
@@ -47,4 +47,12 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     WHERE n.user.id = :userId AND n.confirmed = false
     """)
     void markAllAsReadByUserId(@Param("userId") UUID userId);
+
+    @Modifying
+    @Transactional
+    @Query("""
+    DELETE FROM Notification n
+    WHERE n.confirmed = true AND n.updatedAt < :cutoff
+""")
+    void deleteOldConfirmedNotifications(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,3 +41,6 @@ batch:
   power-user-ranking:
     enabled: true
     cron: "0 10 0 * * *"
+  notification-cleanup:
+    enabled: true
+    cron: "0 15 0 * * *"

--- a/src/test/java/com/twogether/deokhugam/notification/batch/JpaNotificationReaderTest.java
+++ b/src/test/java/com/twogether/deokhugam/notification/batch/JpaNotificationReaderTest.java
@@ -1,0 +1,33 @@
+package com.twogether.deokhugam.notification.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.twogether.deokhugam.notification.batch.reader.JpaNotificationReader;
+import com.twogether.deokhugam.notification.entity.Notification;
+import jakarta.persistence.EntityManagerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+
+class JpaNotificationReaderTest {
+
+    private EntityManagerFactory entityManagerFactory;
+    private JpaNotificationReader reader;
+
+    @BeforeEach
+    void setUp() {
+        entityManagerFactory = mock(EntityManagerFactory.class);
+        reader = new JpaNotificationReader(entityManagerFactory);
+    }
+
+    @Test
+    void create_메서드는_JpaPagingItemReader를_반환한다() {
+        // when
+        JpaPagingItemReader<Notification> itemReader = reader.create();
+
+        // then
+        assertThat(itemReader).isNotNull();
+        assertThat(itemReader.getPageSize()).isEqualTo(100);
+    }
+}

--- a/src/test/java/com/twogether/deokhugam/notification/batch/NotificationCleanupJobTest.java
+++ b/src/test/java/com/twogether/deokhugam/notification/batch/NotificationCleanupJobTest.java
@@ -40,7 +40,8 @@ class NotificationCleanupJobTest {
         List<Notification> remaining = notificationRepository.findAll();
         assertThat(remaining)
             .hasSize(1)
-            .extracting(Notification::getContent)
-            .containsExactly("최근 알림");
+            .extracting(n -> n.getId().toString())
+            .containsExactly("44444444-4444-4444-4444-000000000002");
+
     }
 }

--- a/src/test/java/com/twogether/deokhugam/notification/batch/NotificationCleanupJobTest.java
+++ b/src/test/java/com/twogether/deokhugam/notification/batch/NotificationCleanupJobTest.java
@@ -1,0 +1,46 @@
+package com.twogether.deokhugam.notification.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.twogether.deokhugam.notification.entity.Notification;
+import com.twogether.deokhugam.notification.repository.NotificationRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest
+@SpringBatchTest
+@ActiveProfiles("test")
+@Sql(scripts = "/sql/notification_cleanup_test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class NotificationCleanupJobTest {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    private Job notificationCleanupJob;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Test
+    void 읽은_알림이_7일_지난_경우_삭제된다() throws Exception {
+        // when
+        JobExecution execution = jobLauncher.run(notificationCleanupJob, new JobParameters());
+
+        // then
+        List<Notification> remaining = notificationRepository.findAll();
+        assertThat(remaining)
+            .hasSize(1)
+            .extracting(Notification::getContent)
+            .containsExactly("최근 알림");
+    }
+}

--- a/src/test/java/com/twogether/deokhugam/notification/batch/NotificationDeleteWriterTest.java
+++ b/src/test/java/com/twogether/deokhugam/notification/batch/NotificationDeleteWriterTest.java
@@ -1,0 +1,56 @@
+package com.twogether.deokhugam.notification.batch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.twogether.deokhugam.notification.batch.writer.NotificationDeleteWriter;
+import com.twogether.deokhugam.notification.entity.Notification;
+import com.twogether.deokhugam.notification.repository.NotificationRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.item.Chunk;
+
+class NotificationDeleteWriterTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    private NotificationDeleteWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        writer = new NotificationDeleteWriter(notificationRepository);
+    }
+
+    @Test
+    void 알림이_있으면_일괄삭제한다() throws Exception {
+        // given
+        Notification n1 = mock(Notification.class);
+        Notification n2 = mock(Notification.class);
+        Chunk<Notification> chunk = new Chunk<>(List.of(n1, n2));
+
+        // when
+        writer.write(chunk);
+
+        // then
+        verify(notificationRepository).deleteAllInBatch(List.of(n1, n2));
+    }
+
+    @Test
+    void 알림이_없으면_삭제하지_않는다() throws Exception {
+        // given
+        Chunk<Notification> chunk = new Chunk<>(List.of());
+
+        // when
+        writer.write(chunk);
+
+        // then
+        verify(notificationRepository, never()).deleteAllInBatch(any());
+    }
+}

--- a/src/test/resources/sql/notification_cleanup_test.sql
+++ b/src/test/resources/sql/notification_cleanup_test.sql
@@ -1,0 +1,80 @@
+-- 유저
+INSERT INTO users (
+    id, email, nickname, password, created_at, updated_at, is_deleted
+)
+VALUES (
+           '22222222-2222-2222-2222-000000000001',
+           'user1@example.com',
+           '일간유저',
+           'pw1234',
+           TIMESTAMP '2025-07-22 00:00:00',
+           TIMESTAMP '2025-07-22 00:00:00',
+           FALSE
+       );
+
+-- 도서
+INSERT INTO books (
+    id, title, author, publisher, published_date, review_count, rating, created_at, updated_at, is_deleted, description
+)
+VALUES (
+           '11111111-1111-1111-1111-000000000001',
+           '일간 책',
+           '작가A',
+           '출판사A',
+           DATE '2024-01-01',
+           1,
+           4,
+           TIMESTAMP '2025-07-22 00:00:00',
+           TIMESTAMP '2025-07-22 00:00:00',
+           FALSE,
+           '일간용 도서'
+       );
+
+-- 리뷰
+INSERT INTO reviews (
+    id, book_id, user_id, rating, content, created_at, updated_at, is_deleted,
+    user_nickname, book_title, book_thumbnail_url, like_count, comment_count
+)
+VALUES (
+           '33333333-3333-3333-3333-000000000001',
+           '11111111-1111-1111-1111-000000000001',
+           '22222222-2222-2222-2222-000000000001',
+           4,
+           '일간 리뷰',
+           TIMESTAMP '2025-07-22 09:00:00',
+           TIMESTAMP '2025-07-22 09:00:00',
+           FALSE,
+           '일간유저',
+           '일간 책',
+           'http://image.com/1.jpg',
+           5,
+           2
+       );
+
+-- 삭제 대상 알림 (updated_at이 8일 전)
+INSERT INTO notifications (
+    id, user_id, review_id, content, confirmed, created_at, updated_at
+)
+VALUES (
+           '44444444-4444-4444-4444-000000000001',
+           '22222222-2222-2222-2222-000000000001',
+           '33333333-3333-3333-3333-000000000001',
+           '7일 지난 알림',
+           TRUE,
+           TIMESTAMP '2025-07-10 10:00:00',
+           TIMESTAMP '2025-07-13 10:00:00'
+       );
+
+-- 삭제되지 않아야 할 알림 (updated_at이 하루 전)
+INSERT INTO notifications (
+    id, user_id, review_id, content, confirmed, created_at, updated_at
+)
+VALUES (
+           '44444444-4444-4444-4444-000000000002',
+           '22222222-2222-2222-2222-000000000001',
+           '33333333-3333-3333-3333-000000000001',
+           '최근 알림',
+           TRUE,
+           TIMESTAMP '2025-07-20 10:00:00',
+           TIMESTAMP '2025-07-21 10:00:00'
+       );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#32 

---

## 📝 작업 내용

- 확인된 알림(confirmed = true) 중 1주일이 지난 알림을 자동으로 삭제하는 배치 기능 구현
- 매일 0시 정각에 실행되도록 설정
- JPA 기반 Reader/Writer 구성
- 삭제 조건: updatedAt < (now - 7일)

### 스크린샷 (선택)

---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다  

### 기능 구현
- [ ] 기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [ ] 예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
- [ ] 테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [ ] 실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)

---

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 7일 이상 지난 읽은 알림을 자동으로 정기 삭제하는 배치 작업이 추가되었습니다.
  * 알림 정리 배치 작업이 매일 새벽 0시 15분에 자동 실행되도록 스케줄러가 도입되었습니다.
  * 알림 정리 관련 설정이 환경설정 파일에 추가되었습니다.

* **버그 수정**
  * 인기 도서/리뷰/파워유저 랭킹 배치 작업의 스케줄 설정이 기본값을 가지도록 개선되어, 별도 설정이 없을 때도 자동 실행됩니다.

* **테스트**
  * 알림 정리 배치 및 관련 컴포넌트에 대한 단위 및 통합 테스트가 추가되었습니다.
  * 테스트용 데이터베이스 초기화 SQL이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->