### PR TITLE
Fix: Job 전달 값에 now 누락된 부분 수정

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularBookRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularBookRankingScheduler.java
@@ -39,6 +39,7 @@ public class PopularBookRankingScheduler {
 
                 JobParameters params = new JobParametersBuilder()
                     .addString("period", period.name())
+                    .addString("now", java.time.LocalDateTime.now().toString())
                     .addString("requestId", requestId)
                     .toJobParameters();
 

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularReviewRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularReviewRankingScheduler.java
@@ -38,6 +38,7 @@ public class PopularReviewRankingScheduler {
 
                 JobParameters params = new JobParametersBuilder()
                     .addString("period", period.name())
+                    .addString("now", java.time.LocalDateTime.now().toString())
                     .addString("requestId", requestId)
                     .toJobParameters();
 

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PowerUserRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PowerUserRankingScheduler.java
@@ -43,6 +43,7 @@ public class PowerUserRankingScheduler {
 
                 JobParameters params = new JobParametersBuilder()
                     .addString("period", period.name())
+                    .addString("now", java.time.LocalDateTime.now().toString())
                     .addString("requestId", requestId)
                     .toJobParameters();
 

--- a/src/main/java/com/twogether/deokhugam/notification/batch/reader/JpaNotificationReader.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/reader/JpaNotificationReader.java
@@ -20,7 +20,10 @@ public class JpaNotificationReader {
     }
 
     public JpaPagingItemReader<Notification> create() {
-        LocalDateTime cutoff = LocalDateTime.now().minus(7, ChronoUnit.DAYS);
+        // 테스트용 15분 기준 삭제로 변경
+        LocalDateTime cutoff = LocalDateTime.now().minus(15, ChronoUnit.MINUTES);
+        // 실제 배포 환경 사용
+        //LocalDateTime cutoff = LocalDateTime.now().minus(7, ChronoUnit.DAYS);
 
         Map<String, Object> params = new HashMap<>();
         params.put("cutoff", cutoff);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#6 

---

## 📝 작업 내용
랭킹 배치 스케줄러 개선

- popularBookRankingJob, popularReviewRankingJob, powerUserRankingJob 실행 시 JobParameters에 now 값을 추가로 전달하도록 수정
- 기존에 @Value("#{jobParameters['now']} 방식으로 주입받는 배치 Reader에서 nowString이 null로 인해 NullPointerException이 발생하던 문제 해결

알림 삭제 배치 테스트 조건 적용

- 알림 자동 삭제 배치의 삭제 기준을 7일 → 15분으로 변경 (테스트 용도)
- JpaNotificationReader 내 cutoff = LocalDateTime.now().minus(15, ChronoUnit.MINUTES)로 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 랭킹 관련 작업 실행 시 현재 시각 정보를 추가하여 작업이 실행됩니다.
  * 알림 배치 작업에서 테스트를 위해 알림 필터 기준이 7일에서 15분 전으로 임시 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->