### PR TITLE
Refactor: 랭킹 배치 저장 시 기존 데이터 초기화 추가

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
@@ -3,6 +3,7 @@ package com.twogether.deokhugam.dashboard.batch.writer;
 import com.twogether.deokhugam.common.exception.DeokhugamException;
 import com.twogether.deokhugam.common.exception.ErrorCode;
 import com.twogether.deokhugam.dashboard.entity.PopularBookRanking;
+import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PopularBookRankingRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,9 @@ public class PopularBookRankingWriter implements ItemWriter<PopularBookRanking> 
         }
 
         try {
+            RankingPeriod period = rankingList.get(0).getPeriod();
+            popularBookRankingRepository.deleteByPeriod(period);
+
             for (int i = 0; i < rankingList.size(); i++) {
                 rankingList.get(i).assignRank(i + 1);
             }

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularReviewRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularReviewRankingWriter.java
@@ -3,6 +3,7 @@ package com.twogether.deokhugam.dashboard.batch.writer;
 import com.twogether.deokhugam.common.exception.DeokhugamException;
 import com.twogether.deokhugam.common.exception.ErrorCode;
 import com.twogether.deokhugam.dashboard.entity.PopularReviewRanking;
+import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PopularReviewRankingRepository;
 import com.twogether.deokhugam.notification.event.PopularReviewRankedEvent;
 import com.twogether.deokhugam.notification.service.NotificationService;
@@ -39,6 +40,9 @@ public class PopularReviewRankingWriter implements ItemWriter<PopularReviewRanki
         }
 
         try {
+            RankingPeriod period = rankingList.get(0).getPeriod();
+            popularReviewRankingRepository.deleteByPeriod(period);
+
             for (int i = 0; i < rankingList.size(); i++) {
                 PopularReviewRanking current = rankingList.get(i);
 

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
@@ -3,6 +3,7 @@ package com.twogether.deokhugam.dashboard.batch.writer;
 import com.twogether.deokhugam.common.exception.DeokhugamException;
 import com.twogether.deokhugam.common.exception.ErrorCode;
 import com.twogether.deokhugam.dashboard.entity.PowerUserRanking;
+import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PowerUserRankingRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,9 @@ public class PowerUserRankingWriter implements ItemWriter<PowerUserRanking> {
         }
 
         try {
+            RankingPeriod period = rankingList.get(0).getPeriod();
+            powerUserRankingRepository.deleteByPeriod(period);
+
             int currentRank = 1;
             for (int i = 0; i < rankingList.size(); i++) {
                 PowerUserRanking current = rankingList.get(i);

--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PopularReviewRankingRepository.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PopularReviewRankingRepository.java
@@ -2,11 +2,19 @@ package com.twogether.deokhugam.dashboard.repository;
 
 import com.twogether.deokhugam.dashboard.entity.PopularReviewRanking;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PopularReviewRankingRepository extends JpaRepository<PopularReviewRanking, UUID>, PopularReviewRankingCustomRepository {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PopularReviewRanking r WHERE r.period = :period")
+    void deleteByPeriod(RankingPeriod period);
 
     List<PopularReviewRanking> findByPeriodOrderByRankAsc(RankingPeriod period);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#6 

---

## 📝 작업 내용

- 인기 도서 랭킹 배치
  - PopularBookRankingWriter에서 저장 전 RankingPeriod 기준 기존 데이터 삭제 (deleteByPeriod(...))

- 인기 리뷰 랭킹 배치
  - PopularReviewRankingRepository에 deleteByPeriod() 추가
  - PopularReviewRankingWriter에서 저장 전 삭제 처리 추가

- 파워 유저 랭킹 배치
  - PowerUserRankingWriter에서 저장 전 deleteByPeriod(...) 호출하여 기존 데이터 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 동일한 집계 기간에 대한 이전 인기 도서, 인기 리뷰, 파워 유저 랭킹 데이터가 새로 저장되기 전에 삭제되어, 중복 데이터가 남지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->