### PR TITLE
Fix: 도서 정보 수정 시 리뷰가 업데이트 하도록 수정, 로직 개선

### DIFF
--- a/src/main/java/com/twogether/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/twogether/deokhugam/review/entity/Review.java
@@ -93,8 +93,16 @@ public class Review {
         this.likeCount = likeCount;
     }
 
-    public void updateUpdatedAt(){
-        this.updatedAt = Instant.now();
+    public void updateReviewerNickName(String newUserNickName){
+        this.userNickName = newUserNickName;
+    }
+
+    public void updateBookTitle(String newBookTitle) {
+        this.bookTitle = newBookTitle;
+    }
+
+    public void updateBookThumbnail(String newThumbnailUrl){
+        this.bookThumbnailUrl = newThumbnailUrl;
     }
 
     public void updateReview(String content, int rating){

--- a/src/main/java/com/twogether/deokhugam/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/twogether/deokhugam/review/mapper/ReviewMapper.java
@@ -26,11 +26,6 @@ public class ReviewMapper {
             throw new IllegalStateException("Review가 null 값인 도서나 사용자를 참조하고 있습니다.");
         }
 
-        if (!review.getUserNickName().equals(user.getNickname())){
-            review.updateReviewerNickName(user.getNickname());
-            reviewRepository.save(review);
-        }
-
         return new ReviewDto(
                 review.getId(),
                 book.getId(),

--- a/src/main/java/com/twogether/deokhugam/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/twogether/deokhugam/review/mapper/ReviewMapper.java
@@ -26,6 +26,11 @@ public class ReviewMapper {
             throw new IllegalStateException("Review가 null 값인 도서나 사용자를 참조하고 있습니다.");
         }
 
+        if (!review.getUserNickName().equals(user.getNickname())){
+            review.updateReviewerNickName(user.getNickname());
+            reviewRepository.save(review);
+        }
+
         return new ReviewDto(
                 review.getId(),
                 book.getId(),

--- a/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/twogether/deokhugam/review/repository/ReviewRepository.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRepositoryCustom {
 
-    boolean existsByUserIdAndBookId(UUID userId, UUID bookId);
     boolean existsByUserIdAndBookIdAndIsDeletedFalse(UUID userId, UUID bookId);
 
     @Modifying

--- a/src/main/java/com/twogether/deokhugam/review/repository/custom/ReviewRepositoryImpl.java
+++ b/src/main/java/com/twogether/deokhugam/review/repository/custom/ReviewRepositoryImpl.java
@@ -29,7 +29,10 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QReview review = QReview.review;
 
-    // 리뷰 목록 조회
+    /**
+     * 리뷰 목록 조회
+     */
+    @Override
     public Slice<Review> findReviewsWithCursor(ReviewSearchRequest request, Pageable pageable) {
 
         BooleanBuilder builder = buildSearchCondition(request);
@@ -58,7 +61,9 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
-    // totalElement 구하기
+    /**
+     * totalElement 구하기
+     */
     @Override
     public long totalElementCount(ReviewSearchRequest request) {
 
@@ -75,7 +80,6 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     }
 
     /**
-     *
      * @param keyword 시용자가 입력한 검색어
      * @return 도서 제목, 리뷰 작성자 닉네임, 리류 내용에 keyword가 들어가는지 여부
      */
@@ -92,7 +96,6 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     }
 
     /**
-     *
      * @param keyword 시용자가 입력한 검색어
      * @return OR로 묶인 부분일치 조건들
      */
@@ -109,7 +112,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     }
 
     /**
-     * 중복 로직 분리 메서드
+     * 조회 조건을 build에 and로 넣는 메서드
      */
     private BooleanBuilder buildSearchCondition(ReviewSearchRequest request){
         BooleanBuilder builder = new BooleanBuilder();
@@ -188,7 +191,9 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         }
     }
 
-    // 평점 정렬 시 커서
+    /**
+     * 평점 정렬 시 커서
+     */
     private void ratingCursor(BooleanBuilder builder, Instant afterTime, String cursor, boolean isDesc){
         if (cursor == null){
             if (isDesc) {
@@ -226,7 +231,9 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         }
     }
 
-    // 생성 시간 기준 커서 조건
+    /**
+     * 생성 시간 기준 커서 조건
+     */
     private void createdAtCursor(BooleanBuilder builder, String cursor, boolean isDesc){
         try {
             Instant cursorTime = Instant.parse(cursor);

--- a/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
+++ b/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
@@ -26,6 +26,7 @@ import com.twogether.deokhugam.user.exception.UserNotFoundException;
 import com.twogether.deokhugam.user.repository.UserRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -304,7 +305,8 @@ public class BasicReviewService implements ReviewService{
             updated = true;
         }
 
-        if (!review.getBookThumbnailUrl().equals(review.getBook().getThumbnailUrl())) {
+        // null-safe한 비교
+        if (!Objects.equals(review.getBookThumbnailUrl(), review.getBook().getThumbnailUrl())) {
             review.updateBookThumbnail(review.getBook().getThumbnailUrl());
             updated = true;
         }

--- a/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
+++ b/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
@@ -24,10 +24,10 @@ import com.twogether.deokhugam.review.repository.ReviewLikeRepository;
 import com.twogether.deokhugam.review.repository.ReviewRepository;
 import com.twogether.deokhugam.review.service.util.ReviewCursorHelper;
 import com.twogether.deokhugam.user.entity.User;
+import com.twogether.deokhugam.user.exception.UserNotFoundException;
 import com.twogether.deokhugam.user.repository.UserRepository;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,12 +66,10 @@ public class BasicReviewService implements ReviewService{
 
         // 리뷰 작성하려는 책, 유저
         Book reviewedBook = bookRepository.findById(request.bookId())
-                .orElseThrow(
-                        () -> new NoSuchElementException("책을 찾을 수 없습니다. " + request.bookId()));
+                .orElseThrow(BookNotFoundException::new);
 
         User reviewer = userRepository.findById(request.userId())
-                .orElseThrow(
-                        () -> new NoSuchElementException("사용자를 찾을 수 없습니다. " + request.userId()));
+                .orElseThrow(() -> UserNotFoundException.withId(request.userId()));
 
         Review review = new Review(reviewedBook, reviewer, request.content(), request.rating());
         reviewRepository.save(review);
@@ -230,8 +228,7 @@ public class BasicReviewService implements ReviewService{
         // 좋아요가 비어있다면
         if (reviewLikeRepository.findByUserIdAndReviewId(userId, reviewId).isEmpty()){
             User reviewer = userRepository.findById(userId)
-                    .orElseThrow(
-                            () -> new NoSuchElementException("사용자를 찾을 수 없습니다. " + userId));
+                    .orElseThrow(() -> UserNotFoundException.withId(userId));
 
             ReviewLike newReviewLike = new ReviewLike(
                     review,

--- a/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
+++ b/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
@@ -52,8 +52,6 @@ public class BasicReviewService implements ReviewService{
     private final ReviewCursorHelper reviewCursorHelper;
     // 알림용
     private final ApplicationEventPublisher eventPublisher;
-    private final BookService bookService;
-    private final NotificationService notificationService;
 
     // 리뷰 생성
     @Override
@@ -250,7 +248,7 @@ public class BasicReviewService implements ReviewService{
 
             ReviewLike reviewLike = reviewLikeRepository.findByUserIdAndReviewId(userId, reviewId)
                     .orElseThrow(
-                            () -> new ReviewLikeNotFoundException());
+                            ReviewLikeNotFoundException::new);
 
             if (reviewLike.isLiked()){
                 // 좋아요 상태가 true 라면

--- a/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
+++ b/src/main/java/com/twogether/deokhugam/review/service/BasicReviewService.java
@@ -3,10 +3,8 @@ package com.twogether.deokhugam.review.service;
 import com.twogether.deokhugam.book.entity.Book;
 import com.twogether.deokhugam.book.exception.BookNotFoundException;
 import com.twogether.deokhugam.book.repository.BookRepository;
-import com.twogether.deokhugam.book.service.BookService;
 import com.twogether.deokhugam.common.dto.CursorPageResponseDto;
 import com.twogether.deokhugam.notification.event.ReviewLikedEvent;
-import com.twogether.deokhugam.notification.service.NotificationService;
 import com.twogether.deokhugam.review.dto.ReviewDto;
 import com.twogether.deokhugam.review.dto.ReviewLikeDto;
 import com.twogether.deokhugam.review.dto.request.ReviewCreateRequest;
@@ -53,7 +51,9 @@ public class BasicReviewService implements ReviewService{
     // 알림용
     private final ApplicationEventPublisher eventPublisher;
 
-    // 리뷰 생성
+    /**
+     * 리뷰 생성
+     */
     @Override
     @Transactional
     public ReviewDto create(ReviewCreateRequest request) {
@@ -87,7 +87,9 @@ public class BasicReviewService implements ReviewService{
         return reviewMapper.toDto(review, false);
     }
 
-    // 리뷰 상세 조회
+    /**
+     * 리뷰 상세 조회
+     */
     @Override
     @Transactional(readOnly = true)
     public ReviewDto findById(UUID reviewId, UUID requestUserId){
@@ -105,7 +107,9 @@ public class BasicReviewService implements ReviewService{
         return reviewMapper.toDto(review, likeByMe);
     }
 
-    // 리뷰 목록 조회
+    /**
+     * 리뷰 목록 조회
+     */
     @Override
     @Transactional(readOnly = true)
     public CursorPageResponseDto<ReviewDto> findReviews(ReviewSearchRequest request) {
@@ -126,6 +130,8 @@ public class BasicReviewService implements ReviewService{
                         })
                 .toList();
 
+        log.info("[BasicReviewService]: 리뷰 목록 조회 완료");
+
         // totalElement 구하기
         long totalElement = reviewRepository.totalElementCount(request);
 
@@ -135,8 +141,10 @@ public class BasicReviewService implements ReviewService{
         // after 생성
         String after = slice.hasNext() ? reviewCursorHelper.generateAfter(slice.getContent()) : null;
 
+        log.info("[BasicReviewService]: 리뷰 목록 조회 커서 생성 완료");
+
         // 반환값 생성
-        CursorPageResponseDto<ReviewDto> responseDtoTest = new CursorPageResponseDto<>(
+        return new CursorPageResponseDto<>(
                 reviewDtos,
                 nextCursor,
                 after,
@@ -144,11 +152,11 @@ public class BasicReviewService implements ReviewService{
                 totalElement,
                 slice.hasNext()
         );
-
-        return responseDtoTest;
     }
 
-    // 리뷰 수정 (리뷰 내용, 평점)
+    /**
+     * 리뷰 수정 (리뷰 내용, 별점)
+     */
     @Override
     @Transactional
     public ReviewDto updateReview(UUID reviewId, UUID requestUserId, ReviewUpdateRequest updateRequest) {
@@ -169,7 +177,9 @@ public class BasicReviewService implements ReviewService{
         return reviewMapper.toDto(review, likeByMe);
     }
 
-    // 리뷰 논리 삭제
+    /**
+     * 리뷰 논리 삭제
+     */
     @Override
     @Transactional
     public void deleteReviewSoft(UUID reviewId, UUID requestUserId) {
@@ -192,7 +202,9 @@ public class BasicReviewService implements ReviewService{
         log.info("[BasicReviewService]: 리뷰 논리 삭제 완료");
     }
 
-    // 리뷰 물리 삭제
+    /**
+     * 리뷰 물리 삭제
+     */
     @Override
     @Transactional
     public void deleteReviewHard(UUID reviewId, UUID requestUserId) {
@@ -214,7 +226,9 @@ public class BasicReviewService implements ReviewService{
         log.info("[BasicReviewService]: 리뷰 물리 삭제 완료");
     }
 
-    // 리뷰 좋아요 기능
+    /**
+     * 리뷰 좋아요 기능
+     */
     @Override
     @Transactional
     public ReviewLikeDto reviewLike(UUID reviewId, UUID userId) {
@@ -245,7 +259,6 @@ public class BasicReviewService implements ReviewService{
             return reviewLikeMapper.toDto(newReviewLike);
         }
         else{
-
             ReviewLike reviewLike = reviewLikeRepository.findByUserIdAndReviewId(userId, reviewId)
                     .orElseThrow(
                             ReviewLikeNotFoundException::new);


### PR DESCRIPTION
## 🐛 Problem

리뷰 테이블 구조와 관련된 이슈

### 에러 로그

---

## 🔍 Root Cause
- 리뷰 테이블의 도서 정보 ( 도서 제목, 도서 표지 이미지 url)가 최신 도서 정보를 반영하지 않는 문제

## ✅ Solution
BasicReviewService에 리뷰 메타 데이터 반영 메서드 추가

### 변경사항
- ReviewMapper가 entity와 dto간의 변환 책임만 갖도록 서비스 클래스에 수정 로직 추가하여 리팩토링

---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  
- [x] 변경 사항에 대한 테스트를 했습니다 (버그 수정/기능에 대한 테스트)

---

## 📚 Additional Notes


## 🔗 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 리뷰 작성 시, 책 또는 사용자가 존재하지 않을 경우 더 구체적인 예외 메시지가 제공됩니다.
  * 리뷰 조회 및 목록 조회 시, 사용자 닉네임·책 제목·썸네일 정보가 최신 상태로 자동 동기화됩니다.

* **테스트**
  * 리뷰 내용이 비어있거나 5,000자를 초과할 경우 유효성 검증 테스트가 추가되었습니다.

* **문서화**
  * 주요 서비스 및 저장소 메서드에 Javadoc 스타일 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->