### PR TITLE
Fix: 파워 유저 점수 계산 수정 및 로그 분기 수정

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
@@ -46,8 +46,8 @@ public class JpaPowerUserScoreReader implements ItemReader<PowerUserScoreDto> {
     private List<PowerUserScoreDto> aggregatePowerUserScores() {
         RankingPeriod period = RankingPeriod.valueOf(periodString);
         LocalDateTime now = LocalDateTime.parse(nowString);
-        Instant start = period.getStartTime(now).atZone(ZoneId.of("UTC")).toInstant();
-        Instant end = period.getEndTime(now).atZone(ZoneId.of("UTC")).toInstant();
+        LocalDateTime start = period.getStartTime(now);
+        LocalDateTime end = period.getEndTime(now);
 
         // 1. 작성한 리뷰의 인기 점수
         Map<UUID, Double> reviewScoreMap = em.createQuery("""

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
@@ -6,9 +6,14 @@ import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemReader;
@@ -20,7 +25,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JpaPowerUserScoreReader implements ItemReader<PowerUserScoreDto> {
 
-    private final EntityManager entityManager;
+    private final EntityManager em;
 
     @Value("#{jobParameters['period']}")
     private String periodString;
@@ -33,43 +38,95 @@ public class JpaPowerUserScoreReader implements ItemReader<PowerUserScoreDto> {
     @Override
     public PowerUserScoreDto read() {
         if (iterator == null) {
-            iterator = fetchPowerUserScores().iterator();
+            iterator = aggregatePowerUserScores().iterator();
         }
         return iterator.hasNext() ? iterator.next() : null;
     }
 
-    private List<PowerUserScoreDto> fetchPowerUserScores() {
+    private List<PowerUserScoreDto> aggregatePowerUserScores() {
         RankingPeriod period = RankingPeriod.valueOf(periodString);
         LocalDateTime now = LocalDateTime.parse(nowString);
-
         Instant start = period.getStartTime(now).atZone(ZoneId.of("UTC")).toInstant();
         Instant end = period.getEndTime(now).atZone(ZoneId.of("UTC")).toInstant();
 
-        return entityManager.createQuery("""
-            SELECT u.id, u.nickname,
-                   COALESCE(SUM(COALESCE(r.likeCount, 0) * 0.3 + COALESCE(r.commentCount, 0) * 0.7), 0.0),
-                   COALESCE(SUM(COALESCE(r.likeCount, 0)), 0),
-                   COALESCE(SUM(COALESCE(r.commentCount, 0)), 0)
+        // 1. 작성한 리뷰의 인기 점수
+        Map<UUID, Double> reviewScoreMap = em.createQuery("""
+            SELECT r.user.id, SUM(r.likeCount * 0.3 + r.commentCount * 0.7)
             FROM Review r
-            JOIN r.user u
             WHERE r.createdAt >= :start AND r.createdAt < :end
               AND r.isDeleted = false
-            GROUP BY u.id, u.nickname
-            ORDER BY 3 DESC
+            GROUP BY r.user.id
         """, Object[].class)
             .setParameter("start", start)
             .setParameter("end", end)
-            .setMaxResults(1000)
-            .getResultList()
-            .stream()
-            .map(row -> new PowerUserScoreDto(
-                (UUID) row[0],
-                (String) row[1],
-                ((Number) row[2]).doubleValue(),
-                ((Number) row[3]).longValue(),
-                ((Number) row[4]).longValue(),
+            .getResultList().stream()
+            .collect(Collectors.toMap(
+                row -> (UUID) row[0],
+                row -> ((Number) row[1]).doubleValue()
+            ));
+
+        // 2. 좋아요 참여 수
+        Map<UUID, Long> likeCountMap = em.createQuery("""
+            SELECT l.reviewLikePK.userId, COUNT(l)
+            FROM ReviewLike l
+            WHERE l.liked = true
+              AND l.review.createdAt >= :start AND l.review.createdAt < :end
+            GROUP BY l.reviewLikePK.userId
+        """, Object[].class)
+            .setParameter("start", start)
+            .setParameter("end", end)
+            .getResultList().stream()
+            .collect(Collectors.toMap(
+                row -> (UUID) row[0],
+                row -> ((Number) row[1]).longValue()
+            ));
+
+        // 3. 댓글 참여 수
+        Map<UUID, Long> commentCountMap = em.createQuery("""
+            SELECT c.user.id, COUNT(c)
+            FROM Comment c
+            WHERE c.createdAt >= :start AND c.createdAt < :end
+              AND c.isDeleted = false
+            GROUP BY c.user.id
+        """, Object[].class)
+            .setParameter("start", start)
+            .setParameter("end", end)
+            .getResultList().stream()
+            .collect(Collectors.toMap(
+                row -> (UUID) row[0],
+                row -> ((Number) row[1]).longValue()
+            ));
+
+        // 통합 userId 목록
+        Set<UUID> userIds = new HashSet<>();
+        userIds.addAll(reviewScoreMap.keySet());
+        userIds.addAll(likeCountMap.keySet());
+        userIds.addAll(commentCountMap.keySet());
+
+        // 닉네임 조회
+        Map<UUID, String> nicknameMap = em.createQuery("""
+            SELECT u.id, u.nickname
+            FROM User u
+            WHERE u.id IN :userIds
+        """, Object[].class)
+            .setParameter("userIds", userIds)
+            .getResultList().stream()
+            .collect(Collectors.toMap(
+                row -> (UUID) row[0],
+                row -> (String) row[1]
+            ));
+
+        // DTO 조립 후 정렬
+        return userIds.stream()
+            .map(userId -> new PowerUserScoreDto(
+                userId,
+                nicknameMap.getOrDefault(userId, "알 수 없음"),
+                reviewScoreMap.getOrDefault(userId, 0.0),
+                likeCountMap.getOrDefault(userId, 0L),
+                commentCountMap.getOrDefault(userId, 0L),
                 period
             ))
+            .sorted(Comparator.comparingDouble(PowerUserScoreDto::calculateScore).reversed())
             .toList();
     }
 }

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -104,17 +105,22 @@ public class JpaPowerUserScoreReader implements ItemReader<PowerUserScoreDto> {
         userIds.addAll(commentCountMap.keySet());
 
         // 닉네임 조회
-        Map<UUID, String> nicknameMap = em.createQuery("""
-            SELECT u.id, u.nickname
-            FROM User u
-            WHERE u.id IN :userIds
-        """, Object[].class)
-            .setParameter("userIds", userIds)
-            .getResultList().stream()
-            .collect(Collectors.toMap(
-                row -> (UUID) row[0],
-                row -> (String) row[1]
-            ));
+        Map<UUID, String> nicknameMap;
+        if (userIds.isEmpty()) {
+            nicknameMap = Collections.emptyMap();
+        } else {
+            nicknameMap = em.createQuery("""
+                 SELECT u.id, u.nickname
+                 FROM User u
+                 WHERE u.id IN :userIds
+            """, Object[].class)
+                .setParameter("userIds", userIds)
+                .getResultList().stream()
+                .collect(Collectors.toMap(
+                    row -> (UUID) row[0],
+                    row -> (String) row[1]
+                ));
+        }
 
         // DTO 조립 후 정렬
         return userIds.stream()

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularBookRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularBookRankingScheduler.java
@@ -5,7 +5,9 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -43,9 +45,15 @@ public class PopularBookRankingScheduler {
                     .addString("requestId", requestId)
                     .toJobParameters();
 
-                jobLauncher.run(popularBookRankingJob, params);
+                JobExecution jobExecution = jobLauncher.run(popularBookRankingJob, params);
 
-                log.info("인기 도서 랭킹 배치 성공: period={}, requestId={}", period, requestId);
+                if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+                    log.info("인기 도서 랭킹 배치 성공: period={}, requestId={}", period, requestId);
+                } else {
+                    log.error("인기 도서 랭킹 배치 실패: period={}, requestId={}, status={}",
+                        period, requestId, jobExecution.getStatus());
+                }
+
             } catch (Exception e) {
                 log.error("인기 도서 랭킹 배치 실패: period={}, requestId={}", period, requestId, e);
             } finally {

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularReviewRankingScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/scheduler/PopularReviewRankingScheduler.java
@@ -5,7 +5,9 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -42,9 +44,15 @@ public class PopularReviewRankingScheduler {
                     .addString("requestId", requestId)
                     .toJobParameters();
 
-                jobLauncher.run(popularReviewRankingJob, params);
+                JobExecution jobExecution = jobLauncher.run(popularReviewRankingJob, params);
 
-                log.info("인기 리뷰 랭킹 배치 성공: period={}, requestId={}", period, requestId);
+                if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+                    log.info("인기 리뷰 랭킹 배치 성공: period={}, requestId={}", period, requestId);
+                } else {
+                    log.error("인기 리뷰 랭킹 배치 실패: period={}, requestId={}, status={}",
+                        period, requestId, jobExecution.getStatus());
+                }
+
             } catch (Exception e) {
                 log.error("인기 리뷰 랭킹 배치 실패: period={}, requestId={}", period, requestId, e);
             } finally {

--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingRepository.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PowerUserRankingRepository.java
@@ -2,6 +2,7 @@ package com.twogether.deokhugam.dashboard.repository;
 
 import com.twogether.deokhugam.dashboard.entity.PowerUserRanking;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface PowerUserRankingRepository extends JpaRepository<PowerUserRanking, UUID>, PowerUserRankingCustomRepository {
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM PowerUserRanking r WHERE r.period = :period")
     void deleteByPeriod(RankingPeriod period);
 

--- a/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/scheduler/NotificationCleanupScheduler.java
@@ -2,7 +2,9 @@ package com.twogether.deokhugam.notification.batch.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -28,11 +30,16 @@ public class NotificationCleanupScheduler {
                 .addLong("timestamp", System.currentTimeMillis())
                 .toJobParameters();
 
-            jobLauncher.run(notificationCleanupJob, jobParameters);
+            JobExecution execution = jobLauncher.run(notificationCleanupJob, jobParameters);
 
-            log.info("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 완료");
+            if (execution.getStatus() == BatchStatus.COMPLETED) {
+                log.info("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 성공");
+            } else {
+                log.error("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 실패: status={}", execution.getStatus());
+            }
+
         } catch (Exception e) {
-            log.error("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 실행 중 오류 발생", e);
+            log.error("[NotificationCleanupScheduler] 읽은 알림 삭제 배치 실행 중 예외 발생", e);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#6 

---

## 📝 작업 내용

### 변경 내용

- 다음 4개의 스케줄러 클래스에서 배치 성공 여부를 정확하게 판단하도록 로직 개선:
  - `PowerUserRankingScheduler`
  - `PopularBookRankingScheduler`
  - `PopularReviewRankingScheduler`
  - `NotificationCleanupScheduler`

- `JobExecution.getStatus()`를 통해 `BatchStatus.COMPLETED` 여부를 판단하고,
  그에 따라 `성공/실패 로그`를 분기 처리함

### 개선 이유

- 기존에는 `예외 발생 여부`만으로 배치 성공 여부를 판단하여,
  내부적으로 실패한 배치도 "성공" 로그가 출력될 수 있는 문제가 존재했음

- 배치 실행 결과에 대한 로그 정확도를 높이고, 운영 환경에서의 신뢰성 향상을 위해 개선함

### 테스트

- 기존 배치 실행 후 로그 출력 확인
- 실패 상황에서 로그가 `실패`로 정확히 출력되는지 확인

### 기타

- 추후 `Instant`로 시간 타입 통일 예정이므로 현재 시점에서는 `LocalDateTime` 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 배치 작업 실행 후 실제 완료 상태를 확인하여 성공 또는 실패 여부를 로그에 기록하도록 개선되었습니다. 이제 작업이 정상적으로 완료된 경우에만 성공 로그가 출력되며, 실패 시에는 실패 상태가 함께 기록됩니다.
  * 알림 정리, 파워유저 랭킹, 인기 도서/리뷰 랭킹 등 여러 스케줄러에서 동일하게 적용되었습니다.

* **리팩터**
  * 파워유저 점수 집계 로직이 여러 단계 쿼리와 메모리 내 집계 방식으로 변경되어, 점수 산정의 정확성과 안정성이 향상되었습니다.
  * 일부 변수명 및 메서드명이 명확하게 변경되었습니다.

* **기타**
  * 파워유저 랭킹 데이터 삭제 시 트랜잭션 처리가 명확하게 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->