### PR TITLE
Fix: 테스트 빌드 실패하는 리뷰 단위 테스트 로직 수정

### DIFF
--- a/src/test/java/com/twogether/deokhugam/review/service/BasicReviewServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/review/service/BasicReviewServiceTest.java
@@ -343,6 +343,26 @@ public class BasicReviewServiceTest {
             when(expectedReview1.getId()).thenReturn(reviewId1);
             when(expectedReview2.getId()).thenReturn(reviewId2);
 
+            // 리뷰 정보 동기화 용
+            User mockUser = mock(User.class);
+            when(mockUser.getNickname()).thenReturn("닉네임");
+            when(expectedReview1.getUser()).thenReturn(mockUser);
+            when(expectedReview2.getUser()).thenReturn(mockUser);
+
+            when(expectedReview1.getUserNickName()).thenReturn("닉네임");
+            when(expectedReview2.getUserNickName()).thenReturn("닉네임");
+
+            Book mockBook = mock(Book.class);
+            when(mockBook.getTitle()).thenReturn("책 제목");
+            when(mockBook.getThumbnailUrl()).thenReturn("http://thumbnail.url");
+            when(expectedReview1.getBook()).thenReturn(mockBook);
+            when(expectedReview2.getBook()).thenReturn(mockBook);
+
+            when(expectedReview1.getBookTitle()).thenReturn("책 제목");
+            when(expectedReview2.getBookTitle()).thenReturn("책 제목");
+            when(expectedReview1.getBookThumbnailUrl()).thenReturn("http://thumbnail.url");
+            when(expectedReview2.getBookThumbnailUrl()).thenReturn("http://thumbnail.url");
+
             Pageable pageable = PageRequest.of(0, 50);
             Slice<Review> mockSlice = new SliceImpl<>(expectedResult, pageable, false);
 

--- a/src/test/java/com/twogether/deokhugam/review/service/BasicReviewServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/review/service/BasicReviewServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.twogether.deokhugam.book.entity.Book;
+import com.twogether.deokhugam.book.exception.BookNotFoundException;
 import com.twogether.deokhugam.book.repository.BookRepository;
 import com.twogether.deokhugam.common.dto.CursorPageResponseDto;
 import com.twogether.deokhugam.review.dto.ReviewDto;
@@ -35,6 +36,7 @@ import com.twogether.deokhugam.review.repository.ReviewLikeRepository;
 import com.twogether.deokhugam.review.repository.ReviewRepository;
 import com.twogether.deokhugam.review.service.util.ReviewCursorHelper;
 import com.twogether.deokhugam.user.entity.User;
+import com.twogether.deokhugam.user.exception.UserNotFoundException;
 import com.twogether.deokhugam.user.repository.UserRepository;
 import jakarta.validation.Validator;
 import java.time.LocalDate;
@@ -246,7 +248,7 @@ public class BasicReviewServiceTest {
         when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(NoSuchElementException.class, () -> {
+        assertThrows(BookNotFoundException.class, () -> {
             basicReviewService.create(reviewCreateRequest);
         });
 
@@ -265,7 +267,7 @@ public class BasicReviewServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(NoSuchElementException.class, () -> {
+        assertThrows(UserNotFoundException.class, () -> {
             basicReviewService.create(reviewCreateRequest);
         });
 


### PR DESCRIPTION
## 🐛 Problem

리뷰 단위 테스트와 관련된 이슈

### 에러 로그

---

## 🔍 Root Cause
- 리뷰 생성 테스트 시 유저, 도서 검색 예외에 커스텀 예외로 리팩토링 한 서비스 로직을 반영하지 못하고 있는 문제
- 리뷰 목록 조회 시 리뷰 동기화 메서드에서 NPE가 발생하는 테스트 로직

## ✅ Solution
커스텀 예외를 반환하도록 테스트 로직 수정
리뷰 목록 조회 테스트에 mock 객체를 추가하여 리뷰 동기화 메서드 조건을 통과하도록 수정

### 변경사항
커스텀 예외를 반환하도록 테스트 로직 수정
리뷰 목록 조회 테스트에 mock 객체를 추가하여 리뷰 동기화 메서드 조건을 통과하도록 수정

---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  
- [x] 변경 사항에 대한 테스트를 했습니다 (버그 수정/기능에 대한 테스트)
<img width="1250" height="548" alt="image" src="https://github.com/user-attachments/assets/12b96742-70fa-4ca6-8d72-71e2efcbc206" />


---

## 📚 Additional Notes
테스트 빌드 시 리뷰 테스트에서 발생하던 FAILED 해결

## 🔗 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 예외 처리 테스트를 도메인별 예외(`BookNotFoundException`, `UserNotFoundException`)로 개선하였습니다.
  * 리뷰 목록 반환 테스트에서 사용자 및 도서 정보(Mock) 설정을 강화하여 테스트 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->