### PR TITLE
Refactor: 알림 삭제 기준 원래 상태로 복구

### DIFF
--- a/src/main/java/com/twogether/deokhugam/notification/batch/reader/JpaNotificationReader.java
+++ b/src/main/java/com/twogether/deokhugam/notification/batch/reader/JpaNotificationReader.java
@@ -22,9 +22,9 @@ public class JpaNotificationReader {
     public JpaPagingItemReader<Notification> create(String nowString) {
         Instant now = Instant.parse(nowString);
         // 테스트용 15분 기준 삭제로 변경
-        Instant cutoff = now.minus(15, ChronoUnit.MINUTES);
+//        Instant cutoff = now.minus(15, ChronoUnit.MINUTES);
         // 실제 배포 환경 사용
-//         Instant cutoff = now.minus(7, ChronoUnit.DAYS);
+         Instant cutoff = now.minus(7, ChronoUnit.DAYS);
 
         Map<String, Object> params = new HashMap<>();
         params.put("cutoff", cutoff);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#8 

---

## 📝 작업 내용

각자 테스트 커버리지 확인을 위해 알림 원상 복구
- cutoff 기준 일 단위로 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알림 필터링 기준이 기존 15분에서 7일로 변경되었습니다. 이제 최근 7일 이내의 알림만 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->