### PR TITLE
Test: NotificationQueryService 및 TimeParameterUtil 커버리지 보완

### DIFF
--- a/src/main/java/com/twogether/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/twogether/deokhugam/notification/repository/NotificationRepository.java
@@ -26,6 +26,31 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
         Pageable pageable
     );
 
+    // cursor와 after가 모두 있는 경우
+    @Query("""
+        SELECT n FROM Notification n
+        WHERE n.user.id = :userId AND n.createdAt < :after AND n.createdAt < :cursor
+        ORDER BY n.createdAt DESC, n.id DESC
+    """)
+    List<Notification> findByUserIdWithCursorAndAfter(
+        @Param("userId") UUID userId,
+        @Param("cursor") Instant cursor,
+        @Param("after") Instant after,
+        Pageable pageable
+    );
+
+    // cursor만 있는 경우
+    @Query("""
+        SELECT n FROM Notification n
+        WHERE n.user.id = :userId AND n.createdAt < :cursor
+        ORDER BY n.createdAt DESC, n.id DESC
+    """)
+    List<Notification> findByUserIdWithCursor(
+        @Param("userId") UUID userId,
+        @Param("cursor") Instant cursor,
+        Pageable pageable
+    );
+
     // after가 없는 경우
     @Query("""
         SELECT n FROM Notification n

--- a/src/main/java/com/twogether/deokhugam/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/twogether/deokhugam/notification/service/NotificationQueryService.java
@@ -45,9 +45,20 @@ public class NotificationQueryService {
 
         List<Notification> notifications;
 
-        if (parsedCursor != null) {
-            notifications = notificationRepository.findByUserIdWithAfter(userId, parsedCursor, pageable);
-        } else {
+        // cursor와 after 모두 있는 경우
+        if (parsedCursor != null && after != null) {
+            notifications = notificationRepository.findByUserIdWithCursorAndAfter(userId, parsedCursor, after, pageable);
+        }
+        // cursor만 있는 경우
+        else if (parsedCursor != null) {
+            notifications = notificationRepository.findByUserIdWithCursor(userId, parsedCursor, pageable);
+        }
+        // after만 있는 경우
+        else if (after != null) {
+            notifications = notificationRepository.findByUserIdWithAfter(userId, after, pageable);
+        }
+        // 기본 조회
+        else {
             notifications = notificationRepository.findByUserIdWithoutAfter(userId, pageable);
         }
 

--- a/src/test/java/com/twogether/deokhugam/common/util/TimeParameterUtilTest.java
+++ b/src/test/java/com/twogether/deokhugam/common/util/TimeParameterUtilTest.java
@@ -1,0 +1,27 @@
+package com.twogether.deokhugam.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TimeParameterUtilTest {
+
+    @Test
+    @DisplayName("now 파라미터가 null 또는 blank인 경우 현재 시간 반환")
+    void parseNowOrDefault_nullOrBlank_returnNow() {
+        assertNotNull(TimeParameterUtil.parseNowOrDefault(null));
+        assertNotNull(TimeParameterUtil.parseNowOrDefault(""));
+        assertNotNull(TimeParameterUtil.parseNowOrDefault("   "));
+    }
+
+    @Test
+    @DisplayName("now 파라미터가 정상적인 ISO-8601 문자열이면 파싱된 Instant 반환")
+    void parseNowOrDefault_validString_returnParsed() {
+        String now = "2025-07-24T10:00:00Z";
+        Instant parsed = TimeParameterUtil.parseNowOrDefault(now);
+        assertEquals(Instant.parse(now), parsed);
+    }
+}

--- a/src/test/java/com/twogether/deokhugam/common/util/TimeParameterUtilTest.java
+++ b/src/test/java/com/twogether/deokhugam/common/util/TimeParameterUtilTest.java
@@ -2,7 +2,10 @@ package com.twogether.deokhugam.common.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,5 +26,14 @@ class TimeParameterUtilTest {
         String now = "2025-07-24T10:00:00Z";
         Instant parsed = TimeParameterUtil.parseNowOrDefault(now);
         assertEquals(Instant.parse(now), parsed);
+    }
+
+    @Test
+    @DisplayName("TimeParameterUtil 생성자 private 강제 호출 시 예외 발생")
+    void constructor_invocation_throwsException() throws Exception {
+        Constructor<TimeParameterUtil> constructor = TimeParameterUtil.class.getDeclaredConstructor();
+        constructor.setAccessible(true); // private constructor 호출 가능하게 설정
+
+        assertThrows(InvocationTargetException.class, constructor::newInstance);
     }
 }

--- a/src/test/java/com/twogether/deokhugam/notification/NotificationQueryServiceTest.java
+++ b/src/test/java/com/twogether/deokhugam/notification/NotificationQueryServiceTest.java
@@ -39,7 +39,6 @@ class NotificationQueryServiceTest {
 
     @Test
     void 알림_목록_조회_성공_after_없음() {
-        // given
         UUID userId = UUID.randomUUID();
         Instant baseTime = Instant.now();
         int limit = 2;
@@ -68,29 +67,16 @@ class NotificationQueryServiceTest {
                 .build()
         );
 
-        when(notificationRepository.findByUserIdWithoutAfter(eq(userId), any()))
-            .thenReturn(notifications);
-        when(notificationMapper.toDto(any()))
-            .thenAnswer(invocation -> {
-                Notification n = invocation.getArgument(0);
-                return new NotificationDto(
-                    n.getId(),
-                    userId,
-                    UUID.randomUUID(),
-                    "도서 제목",
-                    n.getContent(),
-                    n.isConfirmed(),
-                    n.getCreatedAt(),
-                    n.getUpdatedAt()
-                );
-            });
+        when(notificationRepository.findByUserIdWithoutAfter(eq(userId), any())).thenReturn(notifications);
+        when(notificationMapper.toDto(any())).thenAnswer(invocation -> {
+            Notification n = invocation.getArgument(0);
+            return new NotificationDto(n.getId(), userId, UUID.randomUUID(), "도서 제목", n.getContent(), n.isConfirmed(), n.getCreatedAt(), n.getUpdatedAt());
+        });
 
-        // when
         CursorPageResponse<NotificationDto> result = notificationQueryService.getNotifications(
             userId, null, null, limit, Sort.Direction.DESC
         );
 
-        // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.isHasNext()).isFalse();
         assertThat(result.getSize()).isEqualTo(2);
@@ -98,60 +84,96 @@ class NotificationQueryServiceTest {
 
     @Test
     void 알림_목록_조회_성공_after_있음() {
-        // given
         UUID userId = UUID.randomUUID();
         Instant baseTime = Instant.now();
         Instant after = baseTime.minus(1, ChronoUnit.HOURS);
-        int limit = 1;
+        int limit = 2;
 
-        User user = mock(User.class);
-        Review review = mock(Review.class);
+        User user1 = mock(User.class);
+        Review review1 = mock(Review.class);
+        User user2 = mock(User.class);
+        Review review2 = mock(Review.class);
 
-        Notification notification = Notification.builder()
+        Notification notification1 = Notification.builder()
             .id(UUID.randomUUID())
             .content("test3")
             .confirmed(false)
             .createdAt(baseTime.minus(10, ChronoUnit.MINUTES))
             .updatedAt(baseTime.minus(10, ChronoUnit.MINUTES))
-            .user(user)
-            .review(review)
+            .user(user1)
+            .review(review1)
             .build();
 
-        Notification anotherNotification = Notification.builder()
+        Notification notification2 = Notification.builder()
             .id(UUID.randomUUID())
             .content("test4")
             .confirmed(false)
-            .createdAt(baseTime.minus(10, ChronoUnit.MINUTES))
-            .updatedAt(baseTime.minus(10, ChronoUnit.MINUTES))
-            .user(user)
-            .review(review)
+            .createdAt(baseTime.minus(20, ChronoUnit.MINUTES))
+            .updatedAt(baseTime.minus(20, ChronoUnit.MINUTES))
+            .user(user2)
+            .review(review2)
             .build();
 
-        when(notificationRepository.findByUserIdWithAfter(eq(userId), eq(after), any()))
-            .thenReturn(List.of(notification, anotherNotification));
-        when(notificationMapper.toDto(any()))
-            .thenAnswer(invocation -> {
-                Notification n = invocation.getArgument(0);
-                return new NotificationDto(
-                    n.getId(),
-                    userId,
-                    UUID.randomUUID(),
-                    "도서 제목",
-                    n.getContent(),
-                    n.isConfirmed(),
-                    n.getCreatedAt(),
-                    n.getUpdatedAt()
-                );
-            });
+        List<Notification> notifications = List.of(notification1, notification2);
 
-        // when
+        when(notificationRepository.findByUserIdWithAfter(eq(userId), eq(after), any()))
+            .thenReturn(notifications);
+
+        when(notificationMapper.toDto(any())).thenAnswer(invocation -> {
+            Notification n = invocation.getArgument(0);
+            return new NotificationDto(
+                n.getId(),
+                userId,
+                UUID.randomUUID(),
+                "도서 제목",
+                n.getContent(),
+                n.isConfirmed(),
+                n.getCreatedAt(),
+                n.getUpdatedAt()
+            );
+        });
+
         CursorPageResponse<NotificationDto> result = notificationQueryService.getNotifications(
-            userId, after.toString(), after, limit, Sort.Direction.DESC
+            userId, null, after, limit, Sort.Direction.DESC
         );
 
-        // then
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.isHasNext()).isTrue();
-        assertThat(result.getSize()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.getSize()).isEqualTo(2);
+    }
+
+    @Test
+    void 알림_목록_조회_성공_cursor만_있는_경우() {
+        UUID userId = UUID.randomUUID();
+        int limit = 1;
+        String cursor = Instant.now().minus(10, ChronoUnit.MINUTES).toString();
+        Instant parsedCursor = Instant.parse(cursor);
+
+        when(notificationRepository.findByUserIdWithCursor(eq(userId), eq(parsedCursor), any())).thenReturn(List.of());
+
+        CursorPageResponse<NotificationDto> result = notificationQueryService.getNotifications(
+            userId, cursor, null, limit, Sort.Direction.DESC
+        );
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void 알림_목록_조회_성공_cursor_and_after_있는_경우() {
+        UUID userId = UUID.randomUUID();
+        String cursor = Instant.now().minus(10, ChronoUnit.MINUTES).toString();
+        Instant parsedCursor = Instant.parse(cursor);
+        Instant after = Instant.now().minus(30, ChronoUnit.MINUTES);
+        int limit = 1;
+
+        when(notificationRepository.findByUserIdWithCursorAndAfter(eq(userId), eq(parsedCursor), eq(after), any())).thenReturn(List.of());
+
+        CursorPageResponse<NotificationDto> result = notificationQueryService.getNotifications(
+            userId, cursor, after, limit, Sort.Direction.DESC
+        );
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.isHasNext()).isFalse();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#8 
---

## 📝 작업 내용

### NotificationQueryServiceTest
- 잘못된 cursor 포맷 입력 시 예외 처리 (`IllegalArgumentException`)
- limit 값이 null, 음수, 100 초과일 때 기본값(20) 적용 확인
- direction 값이 null일 때 기본 정렬(DESC) 적용 확인

### TimeParameterUtilTest
- 유효한 ISO-8601 문자열 파싱 검증
- null, 빈 문자열 입력 시 현재 시간 반환 확인
- private 생성자에 대한 강제 호출 테스트 추가 (UnsupportedOperationException 유도)
### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알림 목록 조회 시 커서 및 after 파라미터 조합에 따라 더욱 세밀한 필터링이 적용됩니다.

* **테스트**
  * 시간 파라미터 유틸리티에 대한 테스트가 추가되었습니다.
  * 알림 조회 서비스의 커서, after, 정렬, 페이지네이션 등 다양한 케이스에 대한 테스트가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->