### PR TITLE
Fix: 인기 리뷰 랭킹 조회 시 점수 기준 정렬 적용

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PopularReviewRankingCustomRepositoryImpl.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PopularReviewRankingCustomRepositoryImpl.java
@@ -77,11 +77,13 @@ public class PopularReviewRankingCustomRepositoryImpl implements PopularReviewRa
         QPopularReviewRanking r = QPopularReviewRanking.popularReviewRanking;
         if ("DESC".equalsIgnoreCase(direction)) {
             return new OrderSpecifier[]{
+                r.score.desc(),
                 r.createdAt.desc(),
                 r.id.desc()
             };
         }
         return new OrderSpecifier[]{
+            r.score.asc(),
             r.createdAt.asc(),
             r.id.asc()
         };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#6 

---

## 📝 작업 내용

- 인기 리뷰 랭킹 조회 시 점수 기준 정렬이 빠져 있어 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인기 리뷰 순위 결과가 이제 점수(score)를 기준으로 우선 정렬됩니다. 동일 점수일 경우 작성일(createdAt)과 ID로 추가 정렬이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->