### PR TITLE
Fix: 인기 리뷰 정렬을 점수에서 랭크로 변경

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/repository/PopularReviewRankingCustomRepositoryImpl.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/repository/PopularReviewRankingCustomRepositoryImpl.java
@@ -77,13 +77,13 @@ public class PopularReviewRankingCustomRepositoryImpl implements PopularReviewRa
         QPopularReviewRanking r = QPopularReviewRanking.popularReviewRanking;
         if ("DESC".equalsIgnoreCase(direction)) {
             return new OrderSpecifier[]{
-                r.score.desc(),
+                r.rank.desc(),
                 r.createdAt.desc(),
                 r.id.desc()
             };
         }
         return new OrderSpecifier[]{
-            r.score.asc(),
+            r.rank.asc(),
             r.createdAt.asc(),
             r.id.asc()
         };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#8 
---

## 📝 작업 내용

- 정렬 순을 `score`에서 `rank`로 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인기 리뷰 순위 정렬 기준이 기존의 점수(score)에서 순위(rank)로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->