### PR TITLE
Refactor: 댓글 API 인터페이스 분리 및 Swagger 문서화 적용

### DIFF
--- a/src/main/java/com/twogether/deokhugam/comments/controller/CommentAPI.java
+++ b/src/main/java/com/twogether/deokhugam/comments/controller/CommentAPI.java
@@ -1,0 +1,258 @@
+package com.twogether.deokhugam.comments.controller;
+
+import com.twogether.deokhugam.comments.dto.CommentCreateRequest;
+import com.twogether.deokhugam.comments.dto.CommentResponse;
+import com.twogether.deokhugam.comments.dto.CommentUpdateRequest;
+import com.twogether.deokhugam.common.dto.CursorPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Tag(name = "댓글 관리 API", description = "댓글 등록/조회/수정/삭제")
+@RequestMapping("/api/comments")
+public interface CommentAPI {
+
+    @Operation(summary = "댓글 등록", description = "리뷰에 댓글을 등록합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "댓글 등록 성공",
+            content = @Content(schema = @Schema(implementation = CommentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:05:34.294Z",
+  "code": "INVALID_INPUT_VALUE",
+  "message": "잘못된 입력값입니다.",
+  "details": {
+    "content": "댓글 내용은 1~200자 이내여야 합니다."
+  },
+  "exceptionType": "MethodArgumentNotValidException",
+  "status": 400
+}
+"""))),
+        @ApiResponse(responseCode = "404", description = "리뷰 정보 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:08:52.777Z",
+  "code": "REVIEW_NOT_FOUND",
+  "message": "리뷰를 찾을 수 없습니다.",
+  "details": {},
+  "exceptionType": "ReviewNotFoundException",
+  "status": 404
+}
+"""))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+            content = @Content(examples = @ExampleObject(value = "댓글 등록 중 서버 오류가 발생했습니다.")))
+    })
+    @PostMapping
+    ResponseEntity<CommentResponse> create(
+        @Parameter(description = "댓글 생성 요청 데이터") @Valid @RequestBody CommentCreateRequest request
+    );
+
+    @Operation(summary = "댓글 목록 조회", description = "시간 역순 + 커서 페이지네이션")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = CursorPageResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (정렬 방향 오류, 페이징 파라미터 오류, 리뷰 ID 누락)",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:14:55.436Z",
+  "code": "MISSING_PARAMETER",
+  "message": "리뷰 ID는 필수입니다.",
+  "details": null,
+  "exceptionType": "MissingRequestParameterException",
+  "status": 400
+}
+"""))),
+        @ApiResponse(responseCode = "404", description = "리뷰 정보 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:13:30.906Z",
+  "code": "REVIEW_NOT_FOUND",
+  "message": "리뷰를 찾을 수 없습니다.",
+  "details": {
+    "reviewId": "1364cc9c-ef00-4680-8e93-c8c72dc6d8a3"
+  },
+  "exceptionType": "ReviewNotFoundException",
+  "status": 404
+}
+"""))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+            content = @Content(examples = @ExampleObject(value = "댓글 목록 조회 중 서버 오류가 발생했습니다.")))
+    })
+    @GetMapping
+    CursorPageResponse<CommentResponse> list(
+        @Parameter(description = "리뷰 ID", required = true)
+        @RequestParam UUID reviewId,
+        @Parameter(description = "정렬 방향", example = "DESC", schema = @Schema(allowableValues = {"ASC", "DESC"}))
+        @RequestParam(defaultValue = "DESC") Direction direction,
+        @Parameter(description = "커서(댓글 ID)")
+        @RequestParam(required = false) String cursor,
+        @Parameter(description = "after 기준 Instant(UTC, ISO 8601)")
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant after,
+        @Parameter(description = "페이지 크기", example = "50")
+        @RequestParam(defaultValue = "50") @Min(1) @Max(100) Integer limit
+    );
+
+    @Operation(summary = "댓글 상세 조회", description = "댓글 ID로 댓글의 상세 정보를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "댓글 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = CommentResponse.class))),
+        @ApiResponse(responseCode = "404", description = "댓글 정보 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:13:30.906Z",
+  "code": "COMMENT_NOT_FOUND",
+  "message": "댓글을 찾을 수 없습니다.",
+  "details": {
+    "commentId": "3f0cce7b-85c5-441a-bc45-8dd726feef44"
+  },
+  "exceptionType": "CommentNotFoundException",
+  "status": 404
+}
+"""))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+            content = @Content(examples = @ExampleObject(value = "댓글 상세 조회 중 서버 오류가 발생했습니다.")))
+    })
+    @GetMapping("/{commentId}")
+    ResponseEntity<CommentResponse> get(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId
+    );
+
+    @Operation(summary = "댓글 수정", description = "본인이 작성한 댓글을 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "댓글 수정 성공",
+            content = @Content(schema = @Schema(implementation = CommentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:18:43.259Z",
+  "code": "INVALID_INPUT_VALUE",
+  "message": "잘못된 입력값입니다.",
+  "details": {
+    "content": "댓글 내용은 1~200자 이내여야 합니다."
+  },
+  "exceptionType": "MethodArgumentNotValidException",
+  "status": 400
+}
+"""))),
+        @ApiResponse(responseCode = "403", description = "댓글 수정 권한 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:18:15.235Z",
+  "code": "COMMENT_NOT_OWNED",
+  "message": "본인이 작성한 댓글만 수정할 수 있습니다.",
+  "details": {},
+  "exceptionType": "CommentNotOwnedException",
+  "status": 403
+}
+"""))),
+        @ApiResponse(responseCode = "404", description = "댓글 정보 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:17:50.466Z",
+  "code": "COMMENT_NOT_FOUND",
+  "message": "댓글을 찾을 수 없습니다.",
+  "details": {
+    "commentId": "3f0cce7b-85c5-441a-bc45-8dd726feef44"
+  },
+  "exceptionType": "CommentNotFoundException",
+  "status": 404
+}
+"""))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+            content = @Content(examples = @ExampleObject(value = "댓글 수정 중 서버 오류가 발생했습니다.")))
+    })
+    @PatchMapping("/{commentId}")
+    ResponseEntity<CommentResponse> update(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
+        @Parameter(description = "요청자 ID", required = true) @RequestHeader("Deokhugam-Request-User-ID") UUID userId,
+        @Parameter(description = "댓글 수정 요청 데이터", required = true) @Valid @RequestBody CommentUpdateRequest request
+    );
+
+    @Operation(summary = "댓글 논리 삭제", description = "본인이 작성한 댓글을 논리적으로 삭제합니다. (isDeleted = true)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "댓글 논리 삭제 성공"),
+        @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:20:40.049Z",
+  "code": "COMMENT_NOT_OWNED",
+  "message": "본인이 작성한 댓글만 삭제할 수 있습니다.",
+  "details": {},
+  "exceptionType": "CommentNotOwnedException",
+  "status": 403
+}
+"""))),
+        @ApiResponse(responseCode = "404", description = "댓글 정보 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:20:57.487Z",
+  "code": "COMMENT_NOT_FOUND",
+  "message": "댓글을 찾을 수 없습니다.",
+  "details": {
+    "commentId": "3f0cce7b-85c5-441a-bc45-8dd726feef44"
+  },
+  "exceptionType": "CommentNotFoundException",
+  "status": 404
+}
+"""))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+            content = @Content(examples = @ExampleObject(value = "댓글 논리 삭제 중 서버 오류가 발생했습니다.")))
+    })
+    @DeleteMapping("/{commentId}")
+    ResponseEntity<Void> logicalDelete(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
+        @Parameter(description = "요청자 ID", required = true) @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    );
+
+    @Operation(summary = "댓글 물리 삭제", description = "본인이 작성한 댓글을 DB에서 영구적으로 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "댓글 물리 삭제 성공"),
+        @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:20:40.049Z",
+  "code": "COMMENT_NOT_OWNED",
+  "message": "본인이 작성한 댓글만 삭제할 수 있습니다.",
+  "details": {},
+  "exceptionType": "CommentNotOwnedException",
+  "status": 403
+}
+"""))),
+        @ApiResponse(responseCode = "404", description = "댓글 정보 없음",
+            content = @Content(examples = @ExampleObject(value = """
+{
+  "timestamp": "2025-07-25T12:20:57.487Z",
+  "code": "COMMENT_NOT_FOUND",
+  "message": "댓글을 찾을 수 없습니다.",
+  "details": {
+    "commentId": "3f0cce7b-85c5-441a-bc45-8dd726feef44"
+  },
+  "exceptionType": "CommentNotFoundException",
+  "status": 404
+}
+"""))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+            content = @Content(examples = @ExampleObject(value = "댓글 물리 삭제 중 서버 오류가 발생했습니다.")))
+    })
+    @DeleteMapping("/{commentId}/hard")
+    ResponseEntity<Void> physicalDelete(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
+        @Parameter(description = "요청자 ID", required = true) @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    );
+}

--- a/src/main/java/com/twogether/deokhugam/comments/controller/CommentController.java
+++ b/src/main/java/com/twogether/deokhugam/comments/controller/CommentController.java
@@ -6,10 +6,6 @@ import com.twogether.deokhugam.comments.dto.CommentUpdateRequest;
 import com.twogether.deokhugam.comments.service.CommentQueryService;
 import com.twogether.deokhugam.comments.service.CommentService;
 import com.twogether.deokhugam.common.dto.CursorPageResponse;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -18,58 +14,26 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Sort.Direction;
 
 import java.time.Instant;
 import java.util.UUID;
 
-import org.springframework.data.domain.Sort.Direction;
-
-/**
- * 댓글 등록 API
- */
 @RestController
 @RequestMapping("/api/comments")
 @RequiredArgsConstructor
-@Tag(name = "댓글 관리 API", description = "댓글 등록/조회/수정/삭제")
-public class CommentController {
+public class CommentController implements CommentAPI {
 
     private final CommentService commentService;
     private final CommentQueryService queryService;
 
-    @Operation(summary = "댓글 등록", description = "리뷰에 댓글을 등록합니다.")
-    @PostMapping
+    @Override
     public ResponseEntity<CommentResponse> create(@Valid @RequestBody CommentCreateRequest request) {
         CommentResponse response = commentService.createComment(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(summary = "댓글 목록 조회", description = "시간 역순 + 커서 페이지네이션")
-    @ApiResponses(value = {
-        @ApiResponse(
-            responseCode = "200",
-            description = "댓글 목록 조회 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = CursorPageResponse.class))
-        ),
-        @ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청 (정렬 방향 오류, 페이징 파라미터 오류, 리뷰 ID 누락)",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = CursorPageResponse.class))
-        ),
-        @ApiResponse(
-            responseCode = "404",
-            description = "리뷰 정보 없음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = CursorPageResponse.class))
-        ),
-        @ApiResponse(
-            responseCode = "500",
-            description = "서버 내부 오류",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = CursorPageResponse.class))
-        )
-    })
-    @GetMapping
+    @Override
     public CursorPageResponse<CommentResponse> list(
         @RequestParam UUID reviewId,
         @RequestParam(defaultValue = "DESC") Direction direction,
@@ -80,26 +44,12 @@ public class CommentController {
         return queryService.getComments(reviewId, direction, cursor, after, limit);
     }
 
-    @Operation(summary = "댓글 상세 조회", description = "댓글 ID로 댓글의 상세 정보를 조회합니다.")
-    @ApiResponses(value = {
-                @ApiResponse(
-                    responseCode = "200",
-                    description = "댓글 상세 조회 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentResponse.class))
-        ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "댓글을 찾을 수 없음",
-                    content = @Content(mediaType = "application/json")
-        )
-        })
-    @GetMapping("/{commentId}")
+    @Override
     public ResponseEntity<CommentResponse> get(@PathVariable UUID commentId) {
         return ResponseEntity.ok(commentService.getComment(commentId));
     }
 
-    @Operation(summary = "댓글 수정", description = "본인이 작성한 댓글을 수정합니다.")
-    @PatchMapping("/{commentId}")
+    @Override
     public ResponseEntity<CommentResponse> update(
         @PathVariable UUID commentId,
         @RequestHeader("Deokhugam-Request-User-ID") UUID userId,
@@ -108,11 +58,7 @@ public class CommentController {
         return ResponseEntity.ok(commentService.updateComment(commentId, userId, request));
     }
 
-    @Operation(
-        summary = "댓글 논리 삭제",
-        description = "본인이 작성한 댓글을 논리적으로 삭제합니다. <br>DB에는 남아 있고, isDeleted가 true로 변경되어 더 이상 조회되지 않습니다."
-    )
-    @DeleteMapping("/{commentId}")
+    @Override
     public ResponseEntity<Void> logicalDelete(
         @PathVariable UUID commentId,
         @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId
@@ -121,11 +67,7 @@ public class CommentController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-        summary = "댓글 물리 삭제",
-        description = "본인이 작성한 댓글을 DB에서 영구적으로 삭제합니다. <br>삭제된 댓글은 복구할 수 없습니다."
-    )
-    @DeleteMapping("/{commentId}/hard")
+    @Override
     public ResponseEntity<Void> physicalDelete(
         @PathVariable UUID commentId,
         @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId
@@ -133,5 +75,4 @@ public class CommentController {
         commentService.deletePhysical(commentId, requestUserId);
         return ResponseEntity.noContent().build();
     }
-
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

---

## 📝 작업 내용

- [x] 댓글 API 인터페이스 분리 및 Swagger 문서화 적용

### 스크린샷 (선택)

---

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  

### 기능 구현
- [x] 기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [x] 예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
- [x] 테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [x] 실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)
<img width="1110" height="165" alt="image" src="https://github.com/user-attachments/assets/0bd78f0d-7779-4bd6-a74e-4417f27e30b4" />

---

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 댓글 생성, 조회, 수정, 삭제(논리/물리) 등 리뷰 관련 댓글을 관리하는 REST API가 추가되었습니다.
  * API는 커서 기반 페이지네이션, 정렬, 상세 조회, 소유자 검증 등 다양한 기능을 제공합니다.

* **문서화**
  * API 명세(Swagger/OpenAPI) 주석이 별도 인터페이스로 분리되어, 컨트롤러 클래스에서는 제거되었습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->