### PR TITLE
Fix: 랭킹 배치 정렬 및 동점 처리 누락 문제 일괄 수정

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
@@ -5,6 +5,7 @@ import com.twogether.deokhugam.common.exception.ErrorCode;
 import com.twogether.deokhugam.dashboard.entity.PopularBookRanking;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PopularBookRankingRepository;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,15 +30,32 @@ public class PopularBookRankingWriter implements ItemWriter<PopularBookRanking> 
         }
 
         try {
+            // 점수 기준 내림차순 정렬
+            rankingList.sort(Comparator.comparingDouble(PopularBookRanking::getScore).reversed());
+
+            // 기간별 기존 랭킹 제거
             RankingPeriod period = rankingList.get(0).getPeriod();
             popularBookRankingRepository.deleteByPeriod(period);
 
+            // 동점 처리 포함 랭크 부여
+            int rank = 1;
+            double prevScore = Double.NEGATIVE_INFINITY;
+
             for (int i = 0; i < rankingList.size(); i++) {
-                rankingList.get(i).assignRank(i + 1);
+                PopularBookRanking current = rankingList.get(i);
+                double score = current.getScore();
+
+                if (Double.compare(score, prevScore) != 0) {
+                    rank = i + 1;
+                }
+
+                current.assignRank(rank);
+                prevScore = score;
             }
 
             popularBookRankingRepository.saveAll(rankingList);
             log.info("인기 도서 랭킹 {}건 저장 완료", rankingList.size());
+
         } catch (Exception e) {
             log.error("인기 도서 랭킹 저장 실패", e);
             throw new DeokhugamException(ErrorCode.RANKING_SAVE_FAILED);

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
@@ -23,7 +23,6 @@ public class PopularBookRankingWriter implements ItemWriter<PopularBookRanking> 
 
     @Override
     public void write(Chunk<? extends PopularBookRanking> items) {
-        // Chunk.getItems()는 UnmodifiableList 반환 → 정렬 위해 복사본 생성
         List<PopularBookRanking> rankingList = new ArrayList<>(items.getItems());
 
         if (rankingList.isEmpty()) {
@@ -32,17 +31,14 @@ public class PopularBookRankingWriter implements ItemWriter<PopularBookRanking> 
         }
 
         try {
-            // 점수 기준 내림차순 + createdAt 기준 내림차순 정렬 (최신 리뷰 우선)
             rankingList.sort(
                 Comparator.comparingDouble(PopularBookRanking::getScore).reversed()
                     .thenComparing(Comparator.comparing(PopularBookRanking::getCreatedAt).reversed())
             );
 
-            // 해당 기간 기존 랭킹 삭제
             RankingPeriod period = rankingList.get(0).getPeriod();
             popularBookRankingRepository.deleteByPeriod(period);
 
-            // 랭크 부여 (동점 처리 포함)
             int rank = 1;
             double prevScore = Double.NEGATIVE_INFINITY;
 

--- a/src/main/java/com/twogether/deokhugam/dashboard/entity/PowerUserRanking.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/entity/PowerUserRanking.java
@@ -67,10 +67,9 @@ public class PowerUserRanking {
     @PositiveOrZero
     private long commentCount;
 
-    @Builder.Default
     @Positive
     @Column(nullable = false)
-    private int rank = 1;
+    private int rank;
 
     @Column(nullable = false, length = 50)
     @NotNull

--- a/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingWriterTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingWriterTest.java
@@ -15,8 +15,9 @@ import com.twogether.deokhugam.dashboard.entity.PowerUserRanking;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PowerUserRankingRepository;
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,55 +39,68 @@ class PowerUserRankingWriterTest {
     @Test
     @DisplayName("여러 개의 파워 유저 랭킹에 순위를 올바르게 부여하고 저장한다")
     void write_multipleRankings_assignSequentialRanks() {
-        PowerUserRanking r1 = createRanking("user1", 12.0);
-        PowerUserRanking r2 = createRanking("user2", 8.0);
-        PowerUserRanking r3 = createRanking("user3", 4.0);
+        PowerUserRanking r1 = createRanking("user1", 12.0, Instant.parse("2025-07-25T10:00:00Z"));
+        PowerUserRanking r2 = createRanking("user2", 8.0, Instant.parse("2025-07-24T10:00:00Z"));
+        PowerUserRanking r3 = createRanking("user3", 4.0, Instant.parse("2025-07-23T10:00:00Z"));
         Chunk<PowerUserRanking> chunk = new Chunk<>(List.of(r1, r2, r3));
 
         writer.write(chunk);
 
-        assertEquals(1, r1.getRank());
-        assertEquals(2, r2.getRank());
-        assertEquals(3, r3.getRank());
-        verify(repository).saveAll(List.of(r1, r2, r3));
+        List<PowerUserRanking> result = new ArrayList<>(List.of(r1, r2, r3));
+        result.sort(Comparator.comparingInt(PowerUserRanking::getRank));
+
+        assertEquals("user1", result.get(0).getNickname());
+        assertEquals(1, result.get(0).getRank());
+
+        assertEquals("user2", result.get(1).getNickname());
+        assertEquals(2, result.get(1).getRank());
+
+        assertEquals("user3", result.get(2).getNickname());
+        assertEquals(3, result.get(2).getRank());
+
+        verify(repository).saveAll(any());
     }
 
     @Test
     @DisplayName("동점자가 있는 경우 같은 순위를 부여하고 다음 순위를 올바르게 계산한다")
     void write_tiedScores_assignCorrectRanks() {
-        PowerUserRanking r1 = createRanking("user1", 10.0);
-        PowerUserRanking r2 = createRanking("user2", 10.0); // 동점
-        PowerUserRanking r3 = createRanking("user3", 8.0);
-        PowerUserRanking r4 = createRanking("user4", 8.0);  // 동점
-        PowerUserRanking r5 = createRanking("user5", 6.0);
+        PowerUserRanking r1 = createRanking("user1", 10.0, Instant.parse("2025-07-25T10:00:00Z"));
+        PowerUserRanking r2 = createRanking("user2", 10.0, Instant.parse("2025-07-24T10:00:00Z"));
+        PowerUserRanking r3 = createRanking("user3", 8.0, Instant.parse("2025-07-23T10:00:00Z"));
+        PowerUserRanking r4 = createRanking("user4", 8.0, Instant.parse("2025-07-22T10:00:00Z"));
+        PowerUserRanking r5 = createRanking("user5", 6.0, Instant.parse("2025-07-21T10:00:00Z"));
         Chunk<PowerUserRanking> chunk = new Chunk<>(List.of(r1, r2, r3, r4, r5));
 
         writer.write(chunk);
 
-        assertEquals(1, r1.getRank()); // 1위
-        assertEquals(1, r2.getRank()); // 1위 (동점)
-        assertEquals(3, r3.getRank()); // 3위 (2위 건너뜀)
-        assertEquals(3, r4.getRank()); // 3위 (동점)
-        assertEquals(5, r5.getRank()); // 5위 (4위 건너뜀)
+        List<PowerUserRanking> result = new ArrayList<>(List.of(r1, r2, r3, r4, r5));
+        result.sort(Comparator.comparingInt(PowerUserRanking::getRank));
+
+        assertEquals("user1", result.get(0).getNickname());
+        assertEquals("user2", result.get(1).getNickname());
+        assertEquals(1, result.get(0).getRank());
+        assertEquals(1, result.get(1).getRank());
+
+        assertEquals("user3", result.get(2).getNickname());
+        assertEquals("user4", result.get(3).getNickname());
+        assertEquals(3, result.get(2).getRank());
+        assertEquals(3, result.get(3).getRank());
+
+        assertEquals("user5", result.get(4).getNickname());
+        assertEquals(5, result.get(4).getRank());
     }
 
     @Test
     @DisplayName("빈 리스트가 들어오면 스킵 처리됨")
     void write_emptyList_skipsWithoutException() {
-        // given
         Chunk<PowerUserRanking> chunk = new Chunk<>(Collections.emptyList());
-
-        // when & then: 예외 없이 정상 종료되는지 확인
         assertThatCode(() -> writer.write(chunk)).doesNotThrowAnyException();
-
-        // (선택) 로그 검증 예시 - logback 테스트 도구를 사용할 경우
-        // verify(log).warn("파워 유저 랭킹 저장 스킵: 저장할 데이터가 없습니다.");
     }
 
     @Test
     @DisplayName("저장 중 예외 발생 시 래핑된 예외 발생")
     void write_repositoryFails_throwsException() {
-        PowerUserRanking ranking = createRanking("user1", 10.0);
+        PowerUserRanking ranking = createRanking("user1", 10.0, Instant.now());
         Chunk<PowerUserRanking> chunk = new Chunk<>(List.of(ranking));
 
         doThrow(new RuntimeException("DB 에러")).when(repository).saveAll(any());
@@ -96,9 +110,9 @@ class PowerUserRankingWriterTest {
             .hasMessageContaining(ErrorCode.RANKING_SAVE_FAILED.getMessage());
     }
 
-    private PowerUserRanking createRanking(String nickname, double score) {
+    private PowerUserRanking createRanking(String nickname, double score, Instant createdAt) {
         return PowerUserRanking.builder()
-            .user(null) // user 객체는 점수 계산에 영향 없음
+            .user(null)
             .nickname(nickname)
             .reviewScoreSum(0.0)
             .likeCount(0L)
@@ -106,7 +120,7 @@ class PowerUserRankingWriterTest {
             .period(RankingPeriod.DAILY)
             .score(score)
             .rank(0)
-            .createdAt(Instant.now())
+            .createdAt(createdAt)
             .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#9 
---

## 📝 작업 내용

- `PopularReviewRankingWriter`:
  - `score` 기준 정렬 추가
  - 동일 점수(dense rank) 처리 방식 개선
- `PopularBookRankingWriter`:
  - 정렬 및 동점 처리 로직 추가
- `PowerUserRankingWriter`:
  - 정렬 누락 보완 및 기존 동점 처리 로직 개선
- 모든 Writer에서 동일한 정렬/동점 처리 방식(`dense rank`)을 따르도록 통일



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 동점 점수가 있는 경우, 동일한 점수에 대해 동일한 순위를 부여하도록 랭킹 산정 로직이 개선되었습니다.
  * 랭킹이 점수로 우선 정렬되고, 동점일 경우 생성일이 더 최근인 항목이 상위에 오도록 정렬 방식이 변경되었습니다.

* **테스트**
  * 동점 및 생성일 기준 랭킹 산정 로직을 검증하는 테스트가 추가 및 개선되었습니다.
  * 테스트 데이터에 명시적으로 생성일을 지정하여 랭킹 결과의 일관성을 높였습니다.

* **스타일/리팩터**
  * 불필요한 기본값 및 주석이 제거되고, 코드 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->