### PR TITLE
Fix: file업로드시 nullpoint 처리 변경

### DIFF
--- a/src/main/java/com/twogether/deokhugam/storage/S3ImageStorage.java
+++ b/src/main/java/com/twogether/deokhugam/storage/S3ImageStorage.java
@@ -43,7 +43,7 @@ public class S3ImageStorage {
         // 고유한 파일명 생성 (UUID + 타임스탬프)
         String originalFileName = imageFile.getOriginalFilename();
         if (originalFileName == null || originalFileName.isBlank()) {
-            throw new IllegalArgumentException("파일명 정보가 없습니다.");
+            originalFileName = "default.jpg";
         }
         String uniqueFileName = generateUniqueFileName(imageFile.getOriginalFilename());
 

--- a/src/main/java/com/twogether/deokhugam/storage/S3ImageStorage.java
+++ b/src/main/java/com/twogether/deokhugam/storage/S3ImageStorage.java
@@ -45,7 +45,7 @@ public class S3ImageStorage {
         if (originalFileName == null || originalFileName.isBlank()) {
             originalFileName = "default.jpg";
         }
-        String uniqueFileName = generateUniqueFileName(imageFile.getOriginalFilename());
+        String uniqueFileName = generateUniqueFileName(originalFileName);
 
         // S3 저장 경로 생성 (폴더경로 + 파일명)
         String s3Key = folderPath + uniqueFileName;


### PR DESCRIPTION
## 📝 작업 내용

- fileUpload시 filename이 null인 경우 default.jpg로 기본확장자 사용 처리

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고 (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다  

### 기능 구현
- [x] 기능 요구사항에 명시된 내용을 정확히 반영했습니다
- [x] 예외 상황 및 유효성 검증을 구현했습니다 (@Valid, 커스텀 예외 등)

### 테스트
- [ ] 테스트 커버리지가 80% 이상이며, 리포트로 확인했습니다 (스크린샷 첨부)
- [x] 실패한 테스트 없이 모든 테스트가 성공했습니다 (./gradlew test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 이미지 업로드 시 파일명이 없거나 비어 있을 경우, 예외를 발생시키지 않고 기본 파일명 "default.jpg"로 처리하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->