### PR TITLE
Fix: db에 제대로 된 랭킹 형성 안되는 문제 해결

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
@@ -33,25 +33,26 @@ public class PopularBookRankingWriter implements ItemWriter<PopularBookRanking> 
         try {
             rankingList.sort(
                 Comparator.comparingDouble(PopularBookRanking::getScore).reversed()
-                    .thenComparing(PopularBookRanking::getCreatedAt, Comparator.reverseOrder())
+                    .thenComparing(PopularBookRanking::getCreatedAt)
             );
 
             RankingPeriod period = rankingList.get(0).getPeriod();
             popularBookRankingRepository.deleteByPeriod(period);
 
-            int rank = 1;
+            int indexRank = 1;
+            int displayedRank = 1;
             double prevScore = Double.NEGATIVE_INFINITY;
 
-            for (int i = 0; i < rankingList.size(); i++) {
-                PopularBookRanking current = rankingList.get(i);
+            for (PopularBookRanking current : rankingList) {
                 double score = current.getScore();
 
                 if (Double.compare(score, prevScore) != 0) {
-                    rank = i + 1;
+                    displayedRank = indexRank;
                 }
 
-                current.assignRank(rank);
+                current.assignRank(displayedRank);
                 prevScore = score;
+                indexRank++;
             }
 
             popularBookRankingRepository.saveAll(rankingList);

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularBookRankingWriter.java
@@ -33,7 +33,7 @@ public class PopularBookRankingWriter implements ItemWriter<PopularBookRanking> 
         try {
             rankingList.sort(
                 Comparator.comparingDouble(PopularBookRanking::getScore).reversed()
-                    .thenComparing(Comparator.comparing(PopularBookRanking::getCreatedAt).reversed())
+                    .thenComparing(PopularBookRanking::getCreatedAt, Comparator.reverseOrder())
             );
 
             RankingPeriod period = rankingList.get(0).getPeriod();

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularReviewRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularReviewRankingWriter.java
@@ -43,25 +43,26 @@ public class PopularReviewRankingWriter implements ItemWriter<PopularReviewRanki
         try {
             rankingList.sort(
                 Comparator.comparingDouble(PopularReviewRanking::getScore).reversed()
-                    .thenComparing(PopularReviewRanking::getCreatedAt, Comparator.reverseOrder())
+                    .thenComparing(PopularReviewRanking::getCreatedAt)
             );
 
             RankingPeriod period = rankingList.get(0).getPeriod();
             popularReviewRankingRepository.deleteByPeriod(period);
 
-            int rank = 1;
+            int indexRank = 1;
+            int displayedRank = 1;
             double prevScore = Double.NEGATIVE_INFINITY;
 
-            for (int i = 0; i < rankingList.size(); i++) {
-                PopularReviewRanking current = rankingList.get(i);
+            for (PopularReviewRanking current : rankingList) {
                 double score = current.getScore();
 
                 if (Double.compare(score, prevScore) != 0) {
-                    rank = i + 1;
+                    displayedRank = indexRank;
                 }
 
-                current.assignRank(rank);
+                current.assignRank(displayedRank);
                 prevScore = score;
+                indexRank++;
             }
 
             popularReviewRankingRepository.saveAll(rankingList);

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularReviewRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PopularReviewRankingWriter.java
@@ -43,7 +43,7 @@ public class PopularReviewRankingWriter implements ItemWriter<PopularReviewRanki
         try {
             rankingList.sort(
                 Comparator.comparingDouble(PopularReviewRanking::getScore).reversed()
-                    .thenComparing(Comparator.comparing(PopularReviewRanking::getCreatedAt).reversed())
+                    .thenComparing(PopularReviewRanking::getCreatedAt, Comparator.reverseOrder())
             );
 
             RankingPeriod period = rankingList.get(0).getPeriod();

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
@@ -35,25 +35,26 @@ public class PowerUserRankingWriter implements ItemWriter<PowerUserRanking> {
         try {
             rankingList.sort(
                 Comparator.comparingDouble(PowerUserRanking::getScore).reversed()
-                    .thenComparing(PowerUserRanking::getCreatedAt, Comparator.reverseOrder())
+                    .thenComparing(PowerUserRanking::getCreatedAt)
             );
 
             RankingPeriod period = rankingList.get(0).getPeriod();
             powerUserRankingRepository.deleteByPeriod(period);
 
-            int rank = 1;
+            int indexRank = 1;
+            int displayedRank = 1;
             double prevScore = Double.NEGATIVE_INFINITY;
 
-            for (int i = 0; i < rankingList.size(); i++) {
-                PowerUserRanking current = rankingList.get(i);
+            for (PowerUserRanking current : rankingList) {
                 double score = current.getScore();
 
                 if (Double.compare(score, prevScore) != 0) {
-                    rank = i + 1;
+                    displayedRank = indexRank;
                 }
 
-                current.assignRank(rank);
+                current.assignRank(displayedRank);
                 prevScore = score;
+                indexRank++;
             }
 
             powerUserRankingRepository.saveAll(rankingList);

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/writer/PowerUserRankingWriter.java
@@ -2,6 +2,7 @@ package com.twogether.deokhugam.dashboard.batch.writer;
 
 import com.twogether.deokhugam.common.exception.DeokhugamException;
 import com.twogether.deokhugam.common.exception.ErrorCode;
+import com.twogether.deokhugam.dashboard.entity.PopularBookRanking;
 import com.twogether.deokhugam.dashboard.entity.PowerUserRanking;
 import com.twogether.deokhugam.dashboard.entity.RankingPeriod;
 import com.twogether.deokhugam.dashboard.repository.PowerUserRankingRepository;
@@ -34,7 +35,7 @@ public class PowerUserRankingWriter implements ItemWriter<PowerUserRanking> {
         try {
             rankingList.sort(
                 Comparator.comparingDouble(PowerUserRanking::getScore).reversed()
-                    .thenComparing(Comparator.comparing(PowerUserRanking::getCreatedAt).reversed())
+                    .thenComparing(PowerUserRanking::getCreatedAt, Comparator.reverseOrder())
             );
 
             RankingPeriod period = rankingList.get(0).getPeriod();

--- a/src/test/java/com/twogether/deokhugam/dashboard/review/PopularReviewRankingWriterTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/review/PopularReviewRankingWriterTest.java
@@ -97,14 +97,14 @@ class PopularReviewRankingWriterTest {
     }
 
     @Test
-    @DisplayName("동점 리뷰는 최신 createdAt 순으로 우선 순위를 부여한다")
-    void writer_shouldAssignRankWithLatestCreatedAtWhenScoresAreEqual() {
+    @DisplayName("동점 리뷰는 createdAt 오름차순으로 우선 순위를 부여한다")
+    void writer_shouldAssignRankWithEarlierCreatedAtWhenScoresAreEqual() {
         // given
         PopularReviewRanking older = createRanking("책1", 9.0, Instant.parse("2025-07-20T10:00:00Z"));
         PopularReviewRanking newer = createRanking("책2", 9.0, Instant.parse("2025-07-21T10:00:00Z"));
         PopularReviewRanking lower = createRanking("책3", 7.0, Instant.parse("2025-07-22T10:00:00Z"));
 
-        Chunk<PopularReviewRanking> chunk = new Chunk<>(List.of(older, newer, lower));
+        Chunk<PopularReviewRanking> chunk = new Chunk<>(List.of(newer, older, lower)); // 일부러 순서 꼬아줌
 
         when(reviewRepository.findAllById(any()))
             .thenReturn(List.of(mock(Review.class), mock(Review.class), mock(Review.class)));
@@ -113,8 +113,8 @@ class PopularReviewRankingWriterTest {
         writer.write(chunk);
 
         // then
-        assertEquals(1, newer.getRank()); // 최신이 먼저
-        assertEquals(1, older.getRank()); // 동점
+        assertEquals(1, older.getRank()); // 더 먼저 생성된 리뷰가 rank 1
+        assertEquals(1, newer.getRank()); // 동점
         assertEquals(3, lower.getRank()); // 낮은 점수
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#9 

---

## 📝 작업 내용

- 각 wrtier `rankingList` 정렬 방식 교체

- 랭킹 정렬 기준을 수정하였습니다.
  - 기존: `score DESC, createdAt DESC`
  - 변경: `score DESC, createdAt ASC`
    - → 동점일 경우 **먼저 생성된 항목**이 더 높은 순위를 갖도록 정렬

- 랭킹 순위 부여 로직을 개선하였습니다.
  - 기존: `rank = i + 1` 단순 증가 방식
  - 변경: `indexRank`, `displayedRank` 분리하여 동점자 처리 안정성 확보
