### PR TITLE
Fix: 대시보드 전체 기간 누락 문제 수정 및 점수 정규화 개선

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
@@ -24,7 +24,7 @@ public record PowerUserScoreDto(
     private static final double COMMENT_COUNT_WEIGHT = 0.3;
 
     public double calculateScore() {
-        double normalizedReviewScore = reviewScoreSum;
+        double normalizedReviewScore = Math.min(reviewScoreSum / 20.0, 1.0);
         double normalizedLike = Math.log1p(likeCount) / 10.0;
         double normalizedComment = Math.log1p(commentCount) / 10.0;
         return (normalizedReviewScore * REVIEW_SCORE_WEIGHT)

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
@@ -24,7 +24,7 @@ public record PowerUserScoreDto(
     private static final double COMMENT_COUNT_WEIGHT = 0.3;
 
     public double calculateScore() {
-        double normalizedReviewScore = reviewScoreSum / 4.0;
+        double normalizedReviewScore = reviewScoreSum;
         double normalizedLike = Math.log1p(likeCount) / 10.0;
         double normalizedComment = Math.log1p(commentCount) / 10.0;
         return (normalizedReviewScore * REVIEW_SCORE_WEIGHT)

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaBookScoreReader.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaBookScoreReader.java
@@ -49,7 +49,7 @@ public class JpaBookScoreReader implements ItemReader<BookScoreDto> {
                    COUNT(r), COALESCE(AVG(r.rating), 0.0)
             FROM Review r
             JOIN r.book b
-            WHERE r.createdAt >= :start AND r.createdAt < :end
+            WHERE r.createdAt >= :start AND r.createdAt <= :end
               AND r.isDeleted = false AND b.isDeleted = false
             GROUP BY b.id, b.title, b.author, b.thumbnailUrl
             ORDER BY COUNT(r) DESC, AVG(r.rating) DESC

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaPowerUserScoreReader.java
@@ -53,7 +53,7 @@ public class JpaPowerUserScoreReader implements ItemReader<PowerUserScoreDto> {
         Map<UUID, Double> reviewScoreMap = em.createQuery("""
             SELECT r.user.id, SUM(r.likeCount * 0.3 + r.commentCount * 0.7)
             FROM Review r
-            WHERE r.createdAt >= :start AND r.createdAt < :end
+            WHERE r.createdAt >= :start AND r.createdAt <= :end
               AND r.isDeleted = false
             GROUP BY r.user.id
         """, Object[].class)
@@ -70,7 +70,7 @@ public class JpaPowerUserScoreReader implements ItemReader<PowerUserScoreDto> {
             SELECT l.reviewLikePK.userId, COUNT(l)
             FROM ReviewLike l
             WHERE l.liked = true
-              AND l.review.createdAt >= :start AND l.review.createdAt < :end
+              AND l.review.createdAt >= :start AND l.review.createdAt <= :end
             GROUP BY l.reviewLikePK.userId
         """, Object[].class)
             .setParameter("start", start)
@@ -85,7 +85,7 @@ public class JpaPowerUserScoreReader implements ItemReader<PowerUserScoreDto> {
         Map<UUID, Long> commentCountMap = em.createQuery("""
             SELECT c.user.id, COUNT(c)
             FROM Comment c
-            WHERE c.createdAt >= :start AND c.createdAt < :end
+            WHERE c.createdAt >= :start AND c.createdAt <= :end
               AND c.isDeleted = false
             GROUP BY c.user.id
         """, Object[].class)

--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaReviewScoreReader.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/reader/JpaReviewScoreReader.java
@@ -52,7 +52,7 @@ public class JpaReviewScoreReader implements ItemReader<ReviewScoreDto> {
             FROM Review r
             JOIN r.user u
             JOIN r.book b
-            WHERE r.createdAt >= :start AND r.createdAt < :end
+            WHERE r.createdAt >= :start AND r.createdAt <= :end
               AND r.isDeleted = false
             ORDER BY COALESCE(r.likeCount, 0) DESC, COALESCE(r.commentCount, 0) DESC
         """, Object[].class)

--- a/src/test/java/com/twogether/deokhugam/dashboard/model/PowerUserScoreDtoTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/model/PowerUserScoreDtoTest.java
@@ -25,22 +25,25 @@ class PowerUserScoreDtoTest {
 
     @ParameterizedTest
     @CsvSource({
-        "20.0,0,0",
-        "20.0,9,9",
-        "40.0,99,0",
-        "16.0,0,99",
-        "0.0,99,99"
+        "20.0,0,0",     // 상한선
+        "40.0,0,0",     // 상한선 초과
+        "10.0,0,0",     // 상한선 이하
+        "40.0,99,0",    // 초과 + like
+        "16.0,0,99",    // 적절한 값 조합
+        "0.0,99,99"     // 리뷰 점수 없음
     })
     void calculateScore_returnsExpectedValue(double reviewScoreSum, long likeCount, long commentCount) {
         PowerUserScoreDto dto = new PowerUserScoreDto(
             UUID.randomUUID(), "테스트유저", reviewScoreSum, likeCount, commentCount, RankingPeriod.DAILY
         );
 
-        double reviewScoreComponent = reviewScoreSum * 0.5;
-        double likeScoreComponent = Math.log1p(likeCount) / 10.0 * 0.2;
-        double commentScoreComponent = Math.log1p(commentCount) / 10.0 * 0.3;
+        double normalizedReview = Math.min(reviewScoreSum / 20.0, 1.0);
+        double normalizedLike = Math.log1p(likeCount) / 10.0;
+        double normalizedComment = Math.log1p(commentCount) / 10.0;
 
-        double expected = reviewScoreComponent + likeScoreComponent + commentScoreComponent;
+        double expected = normalizedReview * 0.5
+            + normalizedLike * 0.2
+            + normalizedComment * 0.3;
 
         assertThat(dto.calculateScore()).isEqualTo(expected, within(1e-6));
     }

--- a/src/test/java/com/twogether/deokhugam/dashboard/model/PowerUserScoreDtoTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/model/PowerUserScoreDtoTest.java
@@ -36,10 +36,11 @@ class PowerUserScoreDtoTest {
             UUID.randomUUID(), "테스트유저", reviewScoreSum, likeCount, commentCount, RankingPeriod.DAILY
         );
 
-        double normalizedReview = reviewScoreSum / 4.0 * 0.5;
-        double normalizedLike = Math.log1p(likeCount) / 10.0 * 0.2;
-        double normalizedComment = Math.log1p(commentCount) / 10.0 * 0.3;
-        double expected = normalizedReview + normalizedLike + normalizedComment;
+        double reviewScoreComponent = reviewScoreSum * 0.5;
+        double likeScoreComponent = Math.log1p(likeCount) / 10.0 * 0.2;
+        double commentScoreComponent = Math.log1p(commentCount) / 10.0 * 0.3;
+
+        double expected = reviewScoreComponent + likeScoreComponent + commentScoreComponent;
 
         assertThat(dto.calculateScore()).isEqualTo(expected, within(1e-6));
     }

--- a/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingBatchTest.java
+++ b/src/test/java/com/twogether/deokhugam/dashboard/user/PowerUserRankingBatchTest.java
@@ -80,7 +80,7 @@ class PowerUserRankingBatchTest {
         } else if (period == RankingPeriod.MONTHLY) {
             assertThat(rankings).hasSize(2);
         } else if (period == RankingPeriod.ALL_TIME) {
-            assertThat(rankings).hasSize(3);
+            assertThat(rankings).hasSize(4);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#128 

---

## 📝 작업 내용

### 변경 내용 요약
1. **전체 기간(ALL_TIME) 점수 누락 문제 수정**
   - `JpaReviewScoreReader` 및 `JpaPowerUserScoreReader`에서 `RankingPeriod.ALL_TIME` 처리 시 `endTime` 계산이 잘못되어 데이터가 일부 누락되는 문제 해결
   - `RankingPeriod.ALL_TIME.getEndTime()`은 `now` 값을 그대로 사용해야 하며, LocalDate 기준으로 잘못 계산되는 문제를 방지

2. **파워 유저 점수 계산 개선 (상한선 방식 도입)**
   - `PowerUserScoreDto`에서 `reviewScoreSum`이 지나치게 높아질 경우 점수가 급격히 커지는 현상을 막기 위해 상한선 방식 도입
     - `normalizedReviewScore = min(reviewScoreSum / 20.0, 1.0)`
   - 이후 기존 가중치(리뷰 50%, 좋아요 20%, 댓글 30%)로 계산
   - 정규화된 점수 계산 방식에 맞게 단위 테스트(`PowerUserScoreDtoTest`)도 수정
   - 
### ⚙️ 최종 점수 계산 공식 (PowerUserScore)

- 점수 = (min(reviewScoreSum / 20.0, 1.0) * 0.5) + (log1p(likeCount) / 10.0 * 0.2) + (log1p(commentCount) / 10.0 * 0.3)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 리뷰, 좋아요, 댓글 집계 시 종료 시각과 정확히 일치하는 데이터도 포함되도록 시간 범위 조건이 변경되었습니다.

* **스타일**
  * 파워유저 점수 계산 방식이 변경되어, 리뷰 점수의 정규화 기준이 20.0으로 조정되고 최대값이 1.0으로 제한되었습니다.

* **테스트**
  * 변경된 점수 계산 로직에 맞춰 테스트 케이스와 예상 결과가 업데이트되었습니다.
  * 파워유저 랭킹 테스트에서 ALL_TIME 기간의 예상 랭킹 수가 3개에서 4개로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->