### PR TITLE
Fix: 파워 유저 점수 수정

### DIFF
--- a/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
+++ b/src/main/java/com/twogether/deokhugam/dashboard/batch/model/PowerUserScoreDto.java
@@ -24,10 +24,9 @@ public record PowerUserScoreDto(
     private static final double COMMENT_COUNT_WEIGHT = 0.3;
 
     public double calculateScore() {
-        double normalizedReviewScore = Math.min(reviewScoreSum / 20.0, 1.0);
         double normalizedLike = Math.log1p(likeCount) / 10.0;
         double normalizedComment = Math.log1p(commentCount) / 10.0;
-        return (normalizedReviewScore * REVIEW_SCORE_WEIGHT)
+        return (reviewScoreSum * REVIEW_SCORE_WEIGHT)
             + (normalizedLike * LIKE_COUNT_WEIGHT)
             + (normalizedComment * COMMENT_COUNT_WEIGHT);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#128 

---

## 📝 작업 내용

- 파워 유저 점수 계산 때 리뷰 점수엔 정규화 미적용되게 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 파워 유저 점수 계산에서 리뷰 점수 합계에 대한 정규화 및 상한 처리가 제거되어, 리뷰 점수 합계가 그대로 가중치와 곱해집니다.

* **테스트**
  * 점수 계산 테스트가 명확하고 구체적인 시나리오별 단위 테스트로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->